### PR TITLE
Add more exceptions to the nobreak rule

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/rules/CheckNoBreak.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/rules/CheckNoBreak.java
@@ -55,7 +55,7 @@ public class CheckNoBreak extends Rule
 		for (int line_cnt = 0; line_cnt < lines.size(); line_cnt++)
 		{
 			String line = lines.get(line_cnt);
-			if (line.matches(".*\\\\begin\\s*\\{\\s*(equation|table|tabular|verbatim|lstlisting|IEEEkeywords|figure).*") || line.matches(".*\\\\\\[.*"))
+			if (line.matches(".*\\\\begin\\s*\\{\\s*(equation|equation\\*|align|align\\*|table|tabular|verbatim|lstlisting|IEEEkeywords|figure|matrix|bmatrix|Bmatrix|pmatrix|vmatrix|Vmatrix|smallmatrix).*") || line.matches(".*\\\\\\[.*"))
 			{
 				env_level++;
 			}
@@ -71,7 +71,7 @@ public class CheckNoBreak extends Rule
 					out_list.add(new Advice(this, r, "You should not break lines manually in a paragraph. Either start a new paragraph or stay in the current one.", original.getResourceName(), original.getLine(start_pos.getLine())));	
 				}
 			}
-			if (line.matches(".*\\\\end\\s*\\{\\s*(equation|table|tabular|verbatim|lstlisting|IEEEkeywords|figure).*") || line.matches(".*\\\\\\].*"))
+			if (line.matches(".*\\\\end\\s*\\{\\s*(equation|equation\\*|align|align\\*|table|tabular|verbatim|lstlisting|IEEEkeywords|figure|matrix|bmatrix|Bmatrix|pmatrix|vmatrix|Vmatrix|smallmatrix).*") || line.matches(".*\\\\\\].*"))
 			{
 				env_level--;
 			}

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/rules/CheckNoBreakTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/rules/CheckNoBreakTest.java
@@ -49,5 +49,17 @@ public class CheckNoBreakTest
 		Rule r = new CheckNoBreak();
 		List<Advice> ad_list = r.evaluate(in_string, in_string);
 		assertEquals(1, ad_list.size());
-	}	
+	}
+
+	@Test
+	public void test3()
+	{
+		AnnotatedString in_string = AnnotatedString.read(new Scanner("\\begin{align*}\n" + 
+				"Lorem ipsum dolor sit amet.\\\\\n" +
+				"Lorem ipsum dolor sit amet.\n"+
+				"\\end{align*}"));
+		Rule r = new CheckNoBreak();
+		List<Advice> ad_list = r.evaluate(in_string, in_string);
+		assertTrue(ad_list.isEmpty());
+	}
 }


### PR DESCRIPTION
The current nobreak rule marks warnings for some equation varients (equation*, align, align*) and the matrix environments.  These environments all require manual line breaking for proper use.
This PR adds those environments to the appropriate regex.

I haven't actually ran the modified version on my machine, since Eclipse couldn't find some file, but I ran in Travis, which can be found at https://travis-ci.org/neil-lindquist/textidote/builds/451664565.
