### PR TITLE
add support for \(\) equation

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
@@ -325,6 +325,7 @@ public class LatexCleaner extends TextCleaner
 		// Other inline equations are replaced by "X"
 		as_out = as_out.replaceAll("([^\\\\])\\$.*?[^\\\\]\\$", "$1X");
 		as_out = as_out.replaceAll("^\\$.*?[^\\\\]\\$", "X");
+		as_out = as_out.replaceAll("\\\\\\(.*?\\\\\\)", "X");
 		// Commands we can ignore
 		as_out = as_out.replaceAll("\\\\\\w+\\{", "");
 		//as_out = as_out.replaceAll("\\\\(title|textbf|textit|emph|uline|section|subsection|subsubsection|paragraph)", "");


### PR DESCRIPTION
Related to #77. I checked with one of my document, using `$$` or `\(\)` inline equations gave me the same errors/warnings