### PR TITLE
Have an easy to parse command line output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 .DS_Store
 
 # Auto-generated folders
-/doc/
+/docs/javadoc/
 /lib/
 /deps/
 /tests/
@@ -47,6 +47,9 @@ jacoco.exec
 **/.settings/
 **/.recommenders/
 **/.loadpath
+
+# vscode-specific
+/.vscode/
 
 # External tool builders
 **/.externalToolBuilders/

--- a/Readme.md
+++ b/Readme.md
@@ -68,14 +68,14 @@ file: an "HTML" report (viewable in a web browser) and a "console" report.
 
 To run TeXtidote and perform a basic verification of the file, run:
 
-    java -jar textidote.jar --html example.tex > report.html
+    java -jar textidote.jar --output html example.tex > report.html
 
 In Linux, if you installed TeXtidote using `apt-get`, you can also call it
 directly by typing:
 
-    textidote --html example.tex > report.html
+    textidote --output html example.tex > report.html
 
-Here, the `--html` option tells TeXtidote to produce a report in HTML format;
+Here, the `--output html` option tells TeXtidote to produce a report in HTML format;
 the `>` symbol indicates that the output should be saved to a file, whose name
 is `report.html`. TeXtidote will run for some time, and print:
 
@@ -103,7 +103,7 @@ will attempt to read one from the standard input.
 ### Plain report
 
 To run TeXtidote and display the results directly in the console, simply omit
-the `--html` option, and do not redirect the output to a file:
+the `--output html` option (you can also use `--output plain`), and do not redirect the output to a file:
 
     java -jar textidote.jar example.tex
 
@@ -111,15 +111,15 @@ TeXtidote will analyze the file like before, but produce a report that looks
 like this:
 
 ```
-* L25C1-L25C25 A section title should start with a capital letter. [sh:001] 
+* L25C1-L25C25 A section title should start with a capital letter. [sh:001]
   \section{a first section}
   ^^^^^^^^^^^^^^^^^^^^^^^^^
-* L38C1-L38C29 A section title should not end with a punctuation symbol. 
-  [sh:002] 
+* L38C1-L38C29 A section title should not end with a punctuation symbol.
+  [sh:002]
   \subsection{ My subsection. }
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-* L15C94-L15C99 Add a space before citation or reference. [sh:c:001] 
-   things, like a citation\cite{my:paper} .The text 
+* L15C94-L15C99 Add a space before citation or reference. [sh:c:001]
+   things, like a citation\cite{my:paper} .The text
 ```
 
 Each element of the list corresponds to a "warning", indicating that
@@ -130,6 +130,25 @@ from the line in question is displayed. The range of characters where the
 problem occurs is marked by the "^^^^" symbols below the text. Each of these
 warnings results from the evaluation of some "rule" on the text; an identifier
 of the rule in question is also shown between brackets.
+
+### Single line report
+
+Another option to display the results directly in the console is the single line report:
+
+    java -jar textidote.jar --output singleline example.tex
+
+Textidote will analyze the file like before, but this time the report looks like this:
+
+```
+example.tex(L25C1-L25C25): A section title should start with a capital letter. "\section{a first section}"
+example.tex(L38C1-L38C29): A section title should not end with a punctuation symbol. "\subsection{ My subsection. }"
+example.tex(L15C94-L15C99): Add a space before citation or reference. "things, like a citation\cite{my:paper} .The text"
+```
+
+Each line corresponds to a warning, and is parseable by regular expressions easily, e.g., for further processing in another tool.
+The file is given at the beginning of the line, followed by the position in parentheses.
+Then, the warning message is given, and the excerpt causing the warning is printed in double quotes ("").
+Note, that sometimes it may happen that a position cannot be determined. In this case, instead of LxxCyy, ? is printed.
 
 ### Spelling, grammar and style
 
@@ -282,8 +301,8 @@ file called `.textidote` in the directory from which it is called. Here is an
 example of what such a file could contain:
 
 ```
---html --read-all 
---replace replacements.txt 
+--output html --read-all
+--replace replacements.txt
 --dict mydict.txt
 --ignore sh:001,sh:d:001
 --check en mytext.tex
@@ -381,7 +400,7 @@ contents, and make this file executable:
 #! /bin/bash
 dir=$(dirname "$1")
 pushd $dir
-java -jar /opt/textidote/textidote.jar --check en --html "$@" > /tmp/textidote.html
+java -jar /opt/textidote/textidote.jar --check en --output html "$@" > /tmp/textidote.html
 popd
 sensible-browser /tmp/textidote.html &
 ```
@@ -494,7 +513,7 @@ If the `--check` option is used, you can add the `--languagemodel xx` option to 
 - If you are writing a research paper, do not hard-code page breaks with
   `\newpage`. [sh:nonp]
 
-### LaTeX subtleties 
+### LaTeX subtleties
 
 - Use a backslash or a comma after the last period in "i.e.", "e.g." and "et al.";
   otherwise LaTeX will think it is a full stop ending a sentence. [sh:010, sh:011]

--- a/Source/Core/src/ca/uqac/lif/textidote/render/SinglelineAdviceRenderer.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/render/SinglelineAdviceRenderer.java
@@ -1,0 +1,93 @@
+/*
+    TeXtidote, a linter for LaTeX documents
+    Copyright (C) 2018-2019  Sylvain Hallé
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package ca.uqac.lif.textidote.render;
+
+import java.util.List;
+import java.util.Map;
+
+import ca.uqac.lif.textidote.Advice;
+import ca.uqac.lif.textidote.AdviceRenderer;
+import ca.uqac.lif.textidote.as.Range;
+import ca.uqac.lif.textidote.as.Position;
+import ca.uqac.lif.util.AnsiPrinter;
+import ca.uqac.lif.util.AnsiPrinter.Color;
+
+/**
+ * Renders advice to a terminal (such as {@code stdin}), printing a single line
+ * per advice, using colored output.
+ */
+public class SinglelineAdviceRenderer extends AdviceRenderer {
+	/**
+	 * Creates a new advice renderer
+	 *
+	 * @param printer The printer to which the advice will be printed
+	 */
+	public SinglelineAdviceRenderer(AnsiPrinter printer) {
+		super(printer);
+	}
+
+	@Override
+	public void render() {
+		for (Map.Entry<String, List<Advice>> entry : m_advice.entrySet()) {
+			String filename = entry.getKey();
+			List<Advice> list = entry.getValue();
+			if (!list.isEmpty()) {
+				for (Advice ad : list) {
+					m_printer.setForegroundColor(Color.YELLOW);
+					m_printer.print(filename + "(" + ad.getRange() + ")");
+					m_printer.resetColors();
+					m_printer.print(": ");
+					m_printer.print(ad.getMessage().replaceAll("<suggestion>", "").replaceAll("</suggestion", "").trim());
+					renderExcerpt(ad.getLine(), ad.getRange());
+					m_printer.println();
+				}
+			}
+		}
+	}
+
+	/**
+	 * Renders a line of text and "highlights" a portion of it. The highlight
+	 * here is represented by printing the text red:
+	 * @param line The line of text
+	 * @param range The range to highlight
+	 */
+	protected void renderExcerpt(/*@ non_null @*/ String line, /*@ non_null @*/ Range range)
+	{
+		m_printer.print(" \"");
+		m_printer.setForegroundColor(Color.WHITE);
+		Position start = range.getStart();
+		Position end = range.getEnd();
+		if(start.compareTo(end) < 0)
+		{
+			m_printer.print(line.substring(0, start.getColumn()));
+			m_printer.setForegroundColor(Color.LIGHT_RED);
+			m_printer.print(line.substring(start.getColumn(), end.getColumn() + 1));
+			m_printer.setForegroundColor(Color.WHITE);
+			if(end.getColumn() + 1 < line.length())
+			{
+				m_printer.print(line.substring(end.getColumn() + 1, line.length()));
+			}
+		}
+		else
+		{
+			m_printer.print(line);
+		}
+		m_printer.resetColors();
+		m_printer.print("\"");
+	}
+}

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/MainTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/MainTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import ca.uqac.lif.textidote.Main;
 import ca.uqac.lif.util.NullPrintStream;
 
-public class MainTest 
+public class MainTest
 {
 	@Test(timeout = 1000)
 	public void test1() throws IOException
@@ -74,7 +74,7 @@ public class MainTest
 		InputStream in = MainTest.class.getResourceAsStream("rules/data/test-stacked-1.tex");
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		PrintStream out = new PrintStream(baos);
-		int ret_code = Main.mainLoop(new String[] {"--html", "--read-all"}, in, out, new NullPrintStream());
+		int ret_code = Main.mainLoop(new String[] {"--output", "html", "--read-all"}, in, out, new NullPrintStream());
 		String output = new String(baos.toByteArray());
 		assertNotNull(output);
 		assertEquals(4, ret_code);
@@ -113,7 +113,7 @@ public class MainTest
 		assertNotNull(output);
 		assertEquals(0, ret_code);
 	}
-	
+
 	@Test(timeout = 20000)
 	public void test9() throws IOException
 	{
@@ -140,7 +140,7 @@ public class MainTest
 		assertEquals(0, ret_code);
 		assertFalse(output.trim().isEmpty());
 	}
-	
+
 	@Test(timeout = 5000)
 	public void testClean2() throws IOException
 	{
@@ -152,7 +152,7 @@ public class MainTest
 		assertNotNull(output);
 		assertEquals(0, ret_code);
 	}
-	
+
 	@Test(timeout = 5000)
 	public void testClean3() throws IOException
 	{
@@ -165,7 +165,7 @@ public class MainTest
 		assertEquals(0, ret_code);
 		assertTrue(output.trim().isEmpty());
 	}
-	
+
 	@Test(timeout = 5000)
 	public void testInput1() throws IOException
 	{
@@ -177,7 +177,7 @@ public class MainTest
 		assertTrue(ret_code > 0);
 		assertFalse(output.trim().isEmpty());
 	}
-	
+
 	@Test(timeout = 5000)
 	public void testNgrams1() throws IOException
 	{

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/as/AnnotatedStringTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/as/AnnotatedStringTest.java
@@ -16,7 +16,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package ca.uqac.lif.textidote.as;
-                                   
+
 import static ca.uqac.lif.textidote.as.AnnotatedString.CRLF;
 import static ca.uqac.lif.textidote.as.AnnotatedString.CRLF_SIZE;
 import static org.junit.Assert.*;
@@ -30,7 +30,7 @@ import ca.uqac.lif.textidote.as.Position;
 import ca.uqac.lif.textidote.as.Range;
 
 @SuppressWarnings("unused")
-public class AnnotatedStringTest 
+public class AnnotatedStringTest
 {
 	@Test
 	public void testLength1()
@@ -39,7 +39,7 @@ public class AnnotatedStringTest
 		as.append("Hello world!");
 		assertEquals(12, as.length());
 	}
-	
+
 	@Test
 	public void testLength2()
 	{
@@ -47,7 +47,7 @@ public class AnnotatedStringTest
 		as.append("Hello").appendNewLine().append("world!");
 		assertEquals(11 + CRLF_SIZE, as.length());
 	}
-	
+
 	@Test
 	public void testAppend1()
 	{
@@ -66,7 +66,7 @@ public class AnnotatedStringTest
 		p = as.getSourcePosition(new Position(1, 7));
 		assertEquals(Position.NOWHERE, p);
 	}
-	
+
 	@Test
 	public void testAppend2()
 	{
@@ -88,7 +88,7 @@ public class AnnotatedStringTest
 		p = as.getSourcePosition(new Position(1, 7));
 		assertEquals(Position.NOWHERE, p);
 	}
-	
+
 	@Test
 	public void testAppend3()
 	{
@@ -110,7 +110,7 @@ public class AnnotatedStringTest
 		p = as.getSourcePosition(new Position(1, 7));
 		assertEquals(Position.NOWHERE, p);
 	}
-	
+
 	@Test
 	public void testAppend4()
 	{
@@ -134,7 +134,7 @@ public class AnnotatedStringTest
 		p = as.getSourcePosition(new Position(1, 7));
 		assertEquals(Position.NOWHERE, p);
 	}
-	
+
 	@Test
 	public void testAppend5()
 	{
@@ -162,7 +162,7 @@ public class AnnotatedStringTest
 		p = as.getSourcePosition(new Position(1, 7));
 		assertEquals(Position.NOWHERE, p);
 	}
-	
+
 	@Test
 	public void testAppend6()
 	{
@@ -188,7 +188,7 @@ public class AnnotatedStringTest
 		p = as.getSourcePosition(new Position(1, 7));
 		assertEquals(Position.NOWHERE, p);
 	}
-	
+
 	@Test
 	public void testAppend7()
 	{
@@ -211,7 +211,7 @@ public class AnnotatedStringTest
 		p = as.getSourcePosition(new Position(1, 7));
 		assertEquals(Position.NOWHERE, p);
 	}
-	
+
 	@Test
 	public void testSubstring1()
 	{
@@ -226,7 +226,7 @@ public class AnnotatedStringTest
 		p = as_sub.getSourcePosition(new Position(0, 4));
 		assertEquals(Position.NOWHERE, p);
 	}
-	
+
 	@Test
 	public void testSubstring2()
 	{
@@ -243,7 +243,7 @@ public class AnnotatedStringTest
 		assertEquals(0, p.getLine());
 		assertEquals(7, p.getColumn());
 	}
-	
+
 	@Test
 	public void testSubstring3()
 	{
@@ -260,7 +260,7 @@ public class AnnotatedStringTest
 		assertEquals(0, p.getLine());
 		assertEquals(7, p.getColumn());
 	}
-	
+
 	@Test
 	public void testFind1()
 	{
@@ -279,7 +279,7 @@ public class AnnotatedStringTest
 		assertEquals(1, p.getLine());
 		assertEquals(0, p.getColumn());
 	}
-	
+
 	@Test
 	public void testReplace1()
 	{
@@ -295,7 +295,7 @@ public class AnnotatedStringTest
 		assertEquals(0, p.getLine());
 		assertEquals(2, p.getColumn());
 	}
-	
+
 	@Test
 	public void testReplace2()
 	{
@@ -311,7 +311,7 @@ public class AnnotatedStringTest
 		assertEquals(0, p.getLine());
 		assertEquals(2, p.getColumn());
 	}
-	
+
 	@Test
 	public void testReplace3()
 	{
@@ -319,9 +319,9 @@ public class AnnotatedStringTest
 		as_orig.append("Hello<!-- c -->world").appendNewLine().append("foobar");
 		AnnotatedString as_rep = as_orig.replaceAll("<", "");
 		assertNotNull(as_rep);
-		assertEquals("Hello!-- c -->world\nfoobar", as_rep.toString());
+		assertEquals(String.format("Hello!-- c -->world%nfoobar"), as_rep.toString());
 	}
-	
+
 	@Test
 	public void testReplace4()
 	{
@@ -334,7 +334,7 @@ public class AnnotatedStringTest
 		assertEquals(0, p.getLine());
 		assertEquals(1, p.getColumn());
 	}
-	
+
 	@Test
 	public void testReplaceAll1()
 	{
@@ -353,7 +353,7 @@ public class AnnotatedStringTest
 		assertEquals(0, p.getLine());
 		assertEquals(8, p.getColumn());
 	}
-	
+
 	@Test
 	public void testGetPosition1()
 	{
@@ -365,7 +365,7 @@ public class AnnotatedStringTest
 		assertEquals(Position.NOWHERE, as.getPosition(-1));
 		assertEquals(Position.NOWHERE, as.getPosition(20));
 	}
-	
+
 	@Test
 	public void testGetPosition2()
 	{
@@ -380,7 +380,7 @@ public class AnnotatedStringTest
 		assertEquals(1, p.getLine());
 		assertEquals(0, p.getColumn());
 	}
-	
+
 	@Test
 	public void testRemoveLine1()
 	{
@@ -394,7 +394,7 @@ public class AnnotatedStringTest
 		assertEquals(1, p.getLine());
 		assertEquals(0, p.getColumn());
 	}
-	
+
 	@Test
 	public void testRemoveLine2()
 	{
@@ -411,7 +411,7 @@ public class AnnotatedStringTest
 		assertEquals(2, p.getLine());
 		assertEquals(1, p.getColumn());
 	}
-	
+
 	@Test
 	public void testTargetPosition1()
 	{
@@ -424,7 +424,7 @@ public class AnnotatedStringTest
 		assertEquals(1, p.getColumn());
 		assertEquals(Position.NOWHERE, as.getTargetPosition(new Position(3, 1)));
 	}
-	
+
 	@Test
 	public void testTargetPosition2()
 	{

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/render/SinglelineAdviceRendererTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/render/SinglelineAdviceRendererTest.java
@@ -1,0 +1,72 @@
+/*
+    TeXtidote, a linter for LaTeX documents
+    Copyright (C) 2018-2019  Sylvain Hallé
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package ca.uqac.lif.textidote.render;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+import ca.uqac.lif.textidote.Advice;
+import ca.uqac.lif.textidote.Rule;
+import ca.uqac.lif.textidote.as.AnnotatedString;
+import ca.uqac.lif.textidote.as.Range;
+import ca.uqac.lif.textidote.as.Position;
+import ca.uqac.lif.util.AnsiPrinter;
+import ca.uqac.lif.textidote.render.SinglelineAdviceRenderer;
+
+public class SinglelineAdviceRendererTest {
+  @Test
+  public void test1() {
+    String filename = "file";
+    String rulename = "rule";
+    String line1 = "foo";
+    String line2 = "bar";
+    String message = "warning message";
+    AnnotatedString as = new AnnotatedString().append(line1).appendNewLine().append(line2).appendNewLine();
+    int startLine = 1;
+    int startCol = 0;
+    int endLine = 1;
+    int endCol = 2;
+    Position start = new Position(startLine, startCol);
+    Position end = new Position(endLine, endCol);
+    Range range = new Range(start, end);
+    Rule rule = new Rule(rulename) {
+      public List<Advice> evaluate(/* @ non_null @ */ AnnotatedString s, /* @ non_null @ */ AnnotatedString original) {
+        return new ArrayList<Advice>();
+      }
+    };
+    ArrayList<Advice> adList = new ArrayList<Advice>();
+    Advice ad = new Advice(rule, range, message, filename, line2);
+    adList.add(ad);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    AnsiPrinter printer = new AnsiPrinter(baos);
+    printer.disableColors();
+    SinglelineAdviceRenderer renderer = new SinglelineAdviceRenderer(printer);
+    renderer.addAdvice(filename, as, adList);
+    renderer.render();
+    String output = new String(baos.toByteArray());
+    assertNotNull(output);
+    String expected = String.format(filename + "(L" + (startLine + 1) + "C" + (startCol + 1) + "-L" + (endLine + 1)
+        + "C" + (endCol + 1) + "): " + message + " \"" + line2 + "\"%n");
+    assertEquals(expected, output);
+  }
+}


### PR DESCRIPTION
Fixes #88 

- Removed command line option `--html`
- Added command line option `--output` with options `plain, html, singleline`
- Updated readme accordingly
- Implemented the feature in class SinglelineAdviceRenderer
- Wrote a simple test for SinglelineAdviceRenderer
- Due to the command line interface change, thest5Html in MainTest.java was broken, fixed it
- Fixed AnnotatedStringTest on Windows (failed due to hardcoded `"\n"` newline character when Windows uses `"\r\n"`)
- Updated gitignore to ignore the generated documentation and Visual Studio Code workspace configuration folder

I'm sorry for the sometimes hard-to-read diff, my editor is configured to remove trailing whitespaces from lines.