### PR TITLE
Support for LanguageTools first language option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -167,6 +167,11 @@ associated to each message back into line/column numbers of the original
 source file. For more information about the kind of verifications made by
 Language Tool, please refer to [its website](https://languagetool.org).
 
+Additionally, the `--firstlang lang` option can be used to make Language Tool check for false friends in your first language.
+For example, to check a text in english, when your first language is german, you may run:
+
+    java -jar textidote.jar --check en --firstlang de example.tex
+
 The language codes you can use are:
 
 - `de`: (Germany) German, and the variants `de_AT` (Austrian) and `de_CH`

--- a/Source/Core/src/ca/uqac/lif/textidote/Main.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/Main.java
@@ -149,6 +149,7 @@ public class Main
 		// Setup command line parser and arguents
 		CliParser cli_parser = new CliParser();
 		cli_parser.addArgument(new Argument().withLongName("check").withArgument("lang").withDescription("Checks grammar in language lang"));
+		cli_parser.addArgument(new Argument().withLongName("firstlang").withArgument("lang").withDescription("Checks for false friends with the author's first language lang and the language specified in --check"));
 		cli_parser.addArgument(new Argument().withLongName("clean").withDescription("Remove markup from input file"));
 		cli_parser.addArgument(new Argument().withLongName("dict").withArgument("file").withDescription("Load dictionary from file"));
 		cli_parser.addArgument(new Argument().withLongName("help").withDescription("\tShow command line usage"));
@@ -429,6 +430,7 @@ public class Main
 		// Do we check the language?
 		List<String> dictionary = new ArrayList<String>();
 		String lang_s = "";
+		String firstlang_s = "";
 		if (map.hasOption("check"))
 		{
 			lang_s = map.getOptionValue("check");
@@ -444,6 +446,10 @@ public class Main
 			catch (FileNotFoundException e)
 			{
 				// Do nothing
+			}
+			if (map.hasOption("firstlang"))
+			{
+				firstlang_s = map.getOptionValue("firstlang");
 			}
 			if (map.hasOption("dict"))
 			{
@@ -587,7 +593,7 @@ public class Main
 				{
 					try
 					{
-						CheckLanguage cl = new CheckLanguage(LanguageFactory.getLanguageFromString(lang_s), dictionary);
+						CheckLanguage cl = new CheckLanguage(LanguageFactory.getLanguageFromString(lang_s), LanguageFactory.getLanguageFromString(firstlang_s), dictionary);
 						if (f_ngram_dir != null)
 						{
 							cl.activateLanguageModelRules(f_ngram_dir);

--- a/Source/Core/src/ca/uqac/lif/textidote/rules/CheckLanguage.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/rules/CheckLanguage.java
@@ -71,11 +71,13 @@ public class CheckLanguage extends Rule
 	 * Creates a new rule for checking a specific language
 	 * @param lang The language to check. If {@code null}, the
 	 * constructor will throw an exception
+	 * @param first_lang The first language of the author.
+	 * Used by LanguageTool to check for false friends.
 	 * @param dictionary A set of words that should be ignored by
 	 * spell checking
 	 * @throws UnsupportedLanguageException If {@code lang} is null
 	 */
-	public CheckLanguage(/*@ nullable @*/ Language lang, /*@ non_null @*/ List<String> dictionary) throws UnsupportedLanguageException
+	public CheckLanguage(/*@ nullable @*/ Language lang, /*@ nullable @*/ Language first_lang, /*@ non_null @*/ List<String> dictionary) throws UnsupportedLanguageException
 	{
 		super("lt:");
 		if (lang == null)
@@ -83,7 +85,14 @@ public class CheckLanguage extends Rule
 			throw new UnsupportedLanguageException();
 		}
 		setName("lt:" + lang.getShortCode());
-		m_languageTool = new MultiThreadedJLanguageTool(lang);
+		if (first_lang == null)
+		{
+			m_languageTool = new MultiThreadedJLanguageTool(lang);
+		}
+		else
+		{
+			m_languageTool = new MultiThreadedJLanguageTool(lang, first_lang);
+		}
 		if (m_disableWhitespace)
 		{
 			m_languageTool.disableRule("WHITESPACE_RULE");
@@ -100,6 +109,19 @@ public class CheckLanguage extends Rule
 
 	/**
 	 * Creates a new rule for checking a specific language
+	 * @param lang The language to check. If {@code null}, the
+	 * constructor will throw an exception
+	 * @param dictionary A set of words that should be ignored by
+	 * spell checking
+	 * @throws UnsupportedLanguageException If {@code lang} is null
+	 */
+	public CheckLanguage(/*@ nullable @*/ Language lang, /*@ non_null @*/ List<String> dictionary) throws UnsupportedLanguageException
+	{
+		this(lang, null, dictionary);
+	}
+
+	/**
+	 * Creates a new rule for checking a specific language
 	 * @param lang The language to check
 	 * @throws UnsupportedLanguageException If {@code lang} is null
 	 */
@@ -109,16 +131,16 @@ public class CheckLanguage extends Rule
 	}
 
 	@Override
-	public List<Advice> evaluate(AnnotatedString s, AnnotatedString original) 
+	public List<Advice> evaluate(AnnotatedString s, AnnotatedString original)
 	{
 		List<Advice> out_list = new ArrayList<Advice>();
 		String s_to_check = s.toString();
 		List<RuleMatch> matches = null;
-		try 
+		try
 		{
 			matches = m_languageTool.check(s_to_check);
 		}
-		catch (IOException e) 
+		catch (IOException e)
 		{
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -134,7 +156,7 @@ public class CheckLanguage extends Rule
 			Position start_pos = s.getPosition(rm.getFromPos());
 			if (!start_pos.equals(Position.NOWHERE))
 			{
-				start_src_pos = s.getSourcePosition(start_pos);				
+				start_src_pos = s.getSourcePosition(start_pos);
 			}
 			Position end_pos = s.getPosition(rm.getToPos());
 			if (!end_pos.equals(Position.NOWHERE))
@@ -208,7 +230,7 @@ public class CheckLanguage extends Rule
 					String word = line.substring(Math.min(line.length() - 1, r.getStart().getColumn()), end_p).trim();
 					if (word.contains("``"))
 					{
-						// This type of quote is OK in LaTeX: ignore 
+						// This type of quote is OK in LaTeX: ignore
 						continue;
 					}
 				}
@@ -229,7 +251,7 @@ public class CheckLanguage extends Rule
 		}
 		return out_list;
 	}
-	
+
 	/**
 	 * Activate rules that depend on a language model. The language model
 	 * currently consists of Lucene indexes with ngram occurrence counts.
@@ -276,7 +298,7 @@ public class CheckLanguage extends Rule
 		 * A description for the rule
 		 */
 		protected String m_description = "";
-		
+
 		public CheckLanguageSpecific(String id, String description)
 		{
 			super(CheckLanguage.this.getName() + ":" + id);
@@ -296,7 +318,7 @@ public class CheckLanguage extends Rule
 		}
 
 		@Override
-		public String getDescription() 
+		public String getDescription()
 		{
 			return m_description;
 		}
@@ -309,20 +331,20 @@ public class CheckLanguage extends Rule
 		 */
 		private static final long serialVersionUID = 1L;
 	}
-	
+
 	public static class IncorrectFolderStructureException extends Exception
 	{
 		/**
 		 * Dummy UID
 		 */
 		private static final long serialVersionUID = 1L;
-		
+
 		public IncorrectFolderStructureException(String message)
 		{
 			super(message);
 		}
 	}
-	
+
 	public static class FolderNotFoundException extends Exception
 	{
 		/**
@@ -332,7 +354,7 @@ public class CheckLanguage extends Rule
 	}
 
 	@Override
-	public String getDescription() 
+	public String getDescription()
 	{
 		return "LanguageTool";
 	}


### PR DESCRIPTION
Fixes #102 

- New command line option `--firstlang lang` to specify the author's first language in order to instruct LanguageTool to check for false friends (must be used in conjuction with --check)
- Updated readme accordingly

**There is no warning if the language code provided for `--firstlang` is not understood.**