### PR TITLE
Ant fails to compile on Windows due to encoding issue

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -191,7 +191,9 @@
       srcdir="${build.srcdir}"
       destdir="${build.bindir}"
       debug="${build.debug}"
-      includeantruntime="false">
+      includeantruntime="false"
+      encoding="utf-8"
+    >
       <classpath refid="build.classpath"/>
     </javac>
     <copy todir="${build.bindir}" includeemptydirs="false">


### PR DESCRIPTION
Trying to compile the latest Textidote myself on Windows (due to lack of a release including recent bugfixes), I ran into an encoding issue (error message below). This PR fixes it.

```
compile:
    [javac] Compiling 37 source files to C:\Users\LocalAdmin\IdeaProjects\textidote\Source\Core\bin
    [javac] warning: [options] bootstrap class path not set in conjunction with -source 1.6
    [javac] C:\Users\LocalAdmin\IdeaProjects\textidote\Source\Core\src\ca\uqac\lif\textidote\cleaning\latex\LatexCleaner.java:440: error: unmappable character for encoding Cp1252
    [javac]             as_out = as_out.replaceAll("\\\\'\\{A\\}", "├?");
    [javac]                                                          ^
    [javac] C:\Users\LocalAdmin\IdeaProjects\textidote\Source\Core\src\ca\uqac\lif\textidote\cleaning\latex\LatexCleaner.java:456: error: unmappable character for encoding Cp1252
    [javac]             as_out = as_out.replaceAll("\\\\'\\{I\\}", "├?");
    [javac]                                                          ^
    [javac] C:\Users\LocalAdmin\IdeaProjects\textidote\Source\Core\src\ca\uqac\lif\textidote\cleaning\latex\LatexCleaner.java:482: error: unmappable character for encoding Cp1252
    [javac]             as_out = as_out.replaceAll("\\\\'A", "├?");
    [javac]                                                    ^
    [javac] C:\Users\LocalAdmin\IdeaProjects\textidote\Source\Core\src\ca\uqac\lif\textidote\cleaning\latex\LatexCleaner.java:498: error: unmappable character for encoding Cp1252
    [javac]             as_out = as_out.replaceAll("\\\\'I", "├?");
    [javac]                                                    ^
    [javac] 4 errors
    [javac] 1 warning

BUILD FAILED
```