### PR TITLE
Fixes #142: dict & language models

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/rules/CheckLanguage.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/rules/CheckLanguage.java
@@ -88,14 +88,18 @@ public class CheckLanguage extends Rule
 		{
 			m_languageTool.disableRule("WHITESPACE_RULE");
 		}
+		m_dictionary = dictionary;
+		handleUserDictionary();
+	}
+
+	public void handleUserDictionary() {
 		for (org.languagetool.rules.Rule rule : m_languageTool.getAllActiveRules())
 		{
 			if (rule instanceof SpellingCheckRule)
 			{
-				((SpellingCheckRule) rule).addIgnoreTokens(dictionary);
+				((SpellingCheckRule) rule).addIgnoreTokens(m_dictionary);
 			}
 		}
-		m_dictionary = dictionary;
 	}
 
 	/**
@@ -244,6 +248,7 @@ public class CheckLanguage extends Rule
 		try
 		{
 			m_languageTool.activateLanguageModelRules(f_ngram_dir);
+			handleUserDictionary();
 		}
 		catch (IOException e)
 		{


### PR DESCRIPTION
Fixes #142.

Dictionary rules are applied again after `activateLanguageModelRules(f_ngram_dir)` is called.
