### PR TITLE
Added dockerfile

### DIFF
--- a/.github/.agp
+++ b/.github/.agp
@@ -1,0 +1,6 @@
+
+Auto Github Push (AGP)
+https://github.com/ms-jpq/auto-github-push
+
+---
+2021-02-01 00:22

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM openjdk:8 AS build
+
+ADD https://downloads.apache.org//ant/binaries/apache-ant-1.10.9-bin.tar.gz /root/ant.tar.gz
+COPY . /build
+WORKDIR /build
+
+RUN tar -xzvf /root/ant.tar.gz && \
+    mv apache-ant* /ant && \
+    /ant/bin/ant download-deps && \
+    /ant/bin/ant
+
+
+FROM openjdk:8
+COPY --from=build /build/textidote.jar /
+ENTRYPOINT ["java", "-jar", "/textidote.jar"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.8"
+
+services:
+  textidote:
+    build: .
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,0 @@
-version: "3.8"
-
-services:
-  textidote:
-    build: .
-


### PR DESCRIPTION
With Docker, you can now use `textidote` without installing `jdk:8` on your system.

This is useful for people who do not want to deal with potentially multiple versions of `java` or do not want to install java on their system for the sole purpose of running `textidote`.

To test, you will need docker:

```sh
sudo apt install docker.io
```

Then you can build `textidote` with

```sh
docker build --tag textidote .
```

After the image finishes building, you can run it using:

```sh
cat somefile.tex | docker run -i --rm textidote
```


