### PR TITLE
add supports for \href command

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
@@ -355,6 +355,8 @@ public class LatexCleaner extends TextCleaner
 		as_out = as_out.replaceAll("\\\\verb\"[^\"]*?\"", "[0]");
 		// Replace references and URLs by dummy placeholder
 		as_out = as_out.replaceAll("\\\\(ref|url|eqref|cref|Cref|vref|Vref|nameref|vpageref|pageref)\\{.*?\\}", "X");
+		// Delete \href command and its url part
+		as_out = as_out.replaceAll("\\\\href\\{.*?\\}", "");
 		// Titles
 		as_out = as_out.replaceAll("\\\\maketitle|\\\\newpage", "");
 		// Font commands

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/LatexCleanerTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/LatexCleanerTest.java
@@ -268,7 +268,16 @@ public class LatexCleanerTest
 		AnnotatedString as = detexer.clean(AnnotatedString.read(new Scanner("\\caption{Hello world. \\label{foo}}")));
 		assertEquals("Hello world. ", as.toString());
 	}
-	
+
+	@Test
+	public void testRemoveReference() throws TextCleanerException
+	{
+		LatexCleaner detexer = new LatexCleaner();
+		detexer.setIgnoreBeforeDocument(false);
+		AnnotatedString as = detexer.clean(AnnotatedString.read(new Scanner("\\href{http://example.org/index.html}{Hello world. }")));
+		assertEquals("Hello world. ", as.toString());
+	}
+
 	@Test
 	public void testRemoveMacros1() throws TextCleanerException
 	{


### PR DESCRIPTION
Currently if <code>\href</code> command is used, textidote will report sh:d:002 error, but this suggestion is not necessary. So I fixed it.
![image](https://user-images.githubusercontent.com/5562899/117793844-397cc100-b27f-11eb-90a1-b82ba507e6e1.png)
