### PR TITLE
Fixed ignored encoding option

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/Main.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/Main.java
@@ -561,7 +561,7 @@ public class Main
 				if (filename.compareTo("--") == 0)
 				{
 					// Open scanner on stdin
-					scanner = new Scanner(in);
+					scanner = new Scanner(in, encoding);
 				}
 				else
 				{
@@ -573,7 +573,7 @@ public class Main
 							stderr.println("File " + filename + " not found (skipping)");
 							continue;
 						}
-						scanner = new Scanner(is);
+						scanner = new Scanner(is, encoding);
 					}
 					else
 					{
@@ -583,7 +583,7 @@ public class Main
 							stderr.println("File " + filename + " not found (skipping)");
 							continue;
 						}
-						scanner = new Scanner(f);
+						scanner = new Scanner(f, encoding);
 					}
 				}
 				num_files++;


### PR DESCRIPTION
I noticed some of my UTF-8 encoded tex files were not being read completely.
Turns out the encoding option was ignored when the `Scanner` was being initialised.
