### PR TITLE
Fix(MarkdownCleaner): Be able to ignore comments, lines and front matter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -403,7 +403,14 @@ understand...
 ```
 
 The lines between `textidote: ignore begin` and `textidote: ignore end` will
-be handled by TeXtidote as if they were comment lines.
+be handled by TeXtidote as if they were comment lines.  
+When you are using markdown you can also selectively ignore parts of the document:
+
+```markdown
+<!-- textidote: ignore begin -->
+This should be ignored
+<!-- textidote: ignore end -->
+```
 
 ## Linux shortcuts
 

--- a/Source/Core/src/ca/uqac/lif/textidote/cleaning/TextCleaner.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/cleaning/TextCleaner.java
@@ -17,9 +17,9 @@
  */
 package ca.uqac.lif.textidote.cleaning;
 
-import java.util.List;
-
 import ca.uqac.lif.textidote.as.AnnotatedString;
+
+import java.util.List;
 
 /**
  * Removes markup from a text file. A text cleaner can perform two kinds
@@ -32,11 +32,20 @@ import ca.uqac.lif.textidote.as.AnnotatedString;
  * <li>A cleanup that only removes blocks of text identified as comments.
  * What a "comment" means depends on the markup language, and some languages
  * may not have comments at all.</li>
- * </ul> 
+ * </ul>
  * @author Sylvain Hallé
  */
-public abstract class TextCleaner 
+public abstract class TextCleaner
 {
+	/**
+	 * The string to look for to tell TeXtidote to start ignoring lines
+	 */
+	public static final String IGNORE_BEGIN = "textidote: ignore begin";
+
+	/**
+	 * The string to look for to tell TeXtidote to stop ignoring lines
+	 */
+	public static final String IGNORE_END = "textidote: ignore end";
 	/**
 	 * Removes markup from a string.
 	 * @param s The original string. Note that this string can be modified
@@ -46,7 +55,7 @@ public abstract class TextCleaner
 	 * @throws TextCleanerException If a problem occurs when cleaning
 	 */
 	/*@ non_null @*/ public abstract AnnotatedString clean(/*@ non_null @*/ AnnotatedString s) throws TextCleanerException;
-	
+
 	/**
 	 * Removes portions of the string identified as comments, but keeps all
 	 * other markup.
@@ -57,7 +66,7 @@ public abstract class TextCleaner
 	 * @throws TextCleanerException If a problem occurs when cleaning
 	 */
 	/*@ non_null @*/ public abstract AnnotatedString cleanComments(/*@ non_null @*/ AnnotatedString s) throws TextCleanerException;
-	
+
 	/**
 	 * Returns the list of inner files included in the file to be cleaned.
 	 * Currently, this only has a meaning for cleaners based on LaTeX,

--- a/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
@@ -17,19 +17,15 @@
  */
 package ca.uqac.lif.textidote.cleaning.latex;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import ca.uqac.lif.textidote.as.AnnotatedString;
 import ca.uqac.lif.textidote.as.Match;
 import ca.uqac.lif.textidote.as.Position;
 import ca.uqac.lif.textidote.cleaning.TextCleaner;
 import ca.uqac.lif.textidote.cleaning.TextCleanerException;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Removes LaTeX markup from an input string, and generates an annotated
@@ -39,15 +35,6 @@ import ca.uqac.lif.textidote.cleaning.TextCleanerException;
  */
 public class LatexCleaner extends TextCleaner
 {
-	/**
-	 * The string to look for to tell TeXtidote to start ignoring lines
-	 */
-	public static final String IGNORE_BEGIN = "textidote: ignore begin";
-
-	/**
-	 * The string to look for to tell TeXtidote to stop ignoring lines
-	 */
-	public static final String IGNORE_END = "textidote: ignore end";
 
 	/**
 	 * Whether the detexer will remove all lines before seeing
@@ -299,7 +286,7 @@ public class LatexCleaner extends TextCleaner
 	}
 
 	/**
-	 * Removes LaTeX commands from a string 
+	 * Removes LaTeX commands from a string
 	 * @param as The string to clean
 	 * @return A string with the environments removed
 	 */
@@ -399,7 +386,7 @@ public class LatexCleaner extends TextCleaner
 	{
 		Match m = null;
 		Position p = Position.ZERO;
-		// Do it one last time for equations at the beginning of a line		
+		// Do it one last time for equations at the beginning of a line
 		m = as_out.find("^\\$.*?[^\\\\]\\$", p);
 		if (m != null)
 		{

--- a/Source/Core/src/ca/uqac/lif/textidote/cleaning/markdown/MarkdownCleaner.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/cleaning/markdown/MarkdownCleaner.java
@@ -84,8 +84,12 @@ public class MarkdownCleaner extends TextCleaner
 			Matcher ignoreStartMatcher = ignoreStartPattern.matcher(line);
 			Matcher ignoreEndRegExMatcher = ignoreEndRegExPattern.matcher(line);
 
+			// Check for end of multiline comment or ignore block
+			// For that, the state has to fit and pattern catch
+			boolean multilineCommentDone = commentState == CommentStates.MULTILINE && endMultilineMatcher.find();
+
 			// Search and handle comment type
-			if (commentState == CommentStates.IGNORE || commentState == CommentStates.MULTILINE) {
+			if (commentState == CommentStates.IGNORE || commentState == CommentStates.MULTILINE && !multilineCommentDone) {
 				// We're in a multiline comment or ignore block. Clean.
 				i = cleanLine(as, i);
 			} else {
@@ -109,14 +113,10 @@ public class MarkdownCleaner extends TextCleaner
 					if (pos >= 0) {
 						// Remove everything from the beginning of the comment till the end of the line
 						as = as.replace("<!--.*", "", new Position(i, pos));
-						i--; // Step counter back so next loop is at same index
 					}
 				}
 			}
 
-			// Check for end of multiline comment or ignore block
-			// For that, the state has to fit and pattern catch
-			boolean multilineCommentDone = commentState == CommentStates.MULTILINE && endMultilineMatcher.find();
 			// Ignore done when ignore end comment or the second closing front matter comment reached
 			boolean ignoreCommentDone =
 					(commentState == CommentStates.IGNORE && ignoreEndRegExMatcher.find()) || (inFrontMatterContent && line.matches(markdownFrontMatterRegEx));

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/MarkdownCleanerTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/MarkdownCleanerTest.java
@@ -59,7 +59,10 @@ public class MarkdownCleanerTest
         AnnotatedString as =
                 markdownCleaner.clean(AnnotatedString.read(new Scanner(Objects.requireNonNull(MarkdownCleanerTest.class.getResourceAsStream("data" +
                         "/markdown-test-1.md")))));
-        assertEquals("Test with comments" + CRLF  + CRLF + "foo  bar" + CRLF + CRLF + "Second comment" + CRLF + CRLF +
+        assertEquals("Test with comments" + CRLF  + CRLF + "foo  bar" + CRLF + "Begin of multiline " + " end " +
+						"comment" + CRLF + CRLF +
+						"Second " +
+						"comment" + CRLF + CRLF +
                         "Some " +
                         "other text",
                 as.toString());

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/MarkdownCleanerTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/MarkdownCleanerTest.java
@@ -17,17 +17,17 @@
  */
 package ca.uqac.lif.textidote.cleaning;
 
+import ca.uqac.lif.textidote.as.AnnotatedString;
+import ca.uqac.lif.textidote.cleaning.markdown.MarkdownCleaner;
+import org.junit.Test;
+
+import java.util.Objects;
+import java.util.Scanner;
+
 import static ca.uqac.lif.textidote.as.AnnotatedString.CRLF;
 import static org.junit.Assert.assertEquals;
 
-import java.util.Scanner;
-
-import org.junit.Test;
-
-import ca.uqac.lif.textidote.as.AnnotatedString;
-import ca.uqac.lif.textidote.cleaning.markdown.MarkdownCleaner;
-
-public class MarkdownCleanerTest 
+public class MarkdownCleanerTest
 {
 	@Test
 	public void testRemoveBold1() throws TextCleanerException
@@ -36,7 +36,7 @@ public class MarkdownCleanerTest
 		AnnotatedString as = detexer.clean(AnnotatedString.read(new Scanner("This is **bold**.")));
 		assertEquals("This is bold.", as.toString());
 	}
-	
+
 	@Test
 	public void testRemoveBackticks1() throws TextCleanerException
 	{
@@ -44,7 +44,7 @@ public class MarkdownCleanerTest
 		AnnotatedString as = detexer.clean(AnnotatedString.read(new Scanner("This is `foo`.")));
 		assertEquals("This is X.", as.toString());
 	}
-	
+
 	@Test
 	public void testRemoveIndentedBlocks1() throws TextCleanerException
 	{
@@ -52,4 +52,27 @@ public class MarkdownCleanerTest
 		AnnotatedString as = detexer.clean(AnnotatedString.read(new Scanner("Here are a few words." + CRLF + CRLF + "    Some code block" + CRLF + CRLF + "Here are some more.")));
 		assertEquals("Here are a few words." + CRLF + CRLF + CRLF + CRLF + "Here are some more.", as.toString());
 	}
+
+    @Test
+    public void testMarkdownCommentsAndFrontMatter() throws TextCleanerException {
+        MarkdownCleaner markdownCleaner = new MarkdownCleaner();
+        AnnotatedString as =
+                markdownCleaner.clean(AnnotatedString.read(new Scanner(Objects.requireNonNull(MarkdownCleanerTest.class.getResourceAsStream("data" +
+                        "/markdown-test-1.md")))));
+        assertEquals("Test with comments" + CRLF  + CRLF + "foo  bar" + CRLF + CRLF + "Second comment" + CRLF + CRLF +
+                        "Some " +
+                        "other text",
+                as.toString());
+    }
+
+    @Test
+    public void testMarkdownIgnoreComments() throws TextCleanerException {
+        MarkdownCleaner markdownCleaner = new MarkdownCleaner();
+        AnnotatedString as =
+                markdownCleaner.clean(AnnotatedString.read(new Scanner(Objects.requireNonNull(MarkdownCleanerTest.class.getResourceAsStream("data" +
+                        "/markdown-test-2.md")))));
+        assertEquals("TexTidote ignore test file" + CRLF + CRLF + "some words" + CRLF + CRLF + "Ignore everything " +
+                        "below" + CRLF,
+                as.toString());
+    }
 }

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/data/markdown-test-1.md
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/data/markdown-test-1.md
@@ -1,0 +1,18 @@
+---
+eleventyNavigation:
+key: ExamplePage
+title: Example Page
+layout: default_layout
+---
+# Test with comments
+
+<!-- this is a regular comment before -->
+foo <!-- this is an inline comment --> bar
+<!-- this is a regular comment after -->
+<!-- A
+multiline
+comment -->
+
+## Second comment
+
+Some other text

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/data/markdown-test-1.md
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/data/markdown-test-1.md
@@ -9,9 +9,9 @@ layout: default_layout
 <!-- this is a regular comment before -->
 foo <!-- this is an inline comment --> bar
 <!-- this is a regular comment after -->
-<!-- A
+Begin of multiline <!-- A
 multiline
-comment -->
+comment --> end comment
 
 ## Second comment
 

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/data/markdown-test-2.md
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/data/markdown-test-2.md
@@ -1,0 +1,15 @@
+# TexTidote ignore test file
+
+<!-- textidote: ignore begin -->
+This should be ignored
+<!-- textidote: ignore end -->
+<!-- This and the below comment should not have any effect on "some words" -->
+<!-- textidote: ignore end -->
+some words
+
+## Ignore everything below
+
+<!-- textidote: ignore begin -->
+All of this should now be ignored.
+Also this.
+And This


### PR DESCRIPTION
### Changes:

- [x] Ignore regular, inline and multiline comments
- [x] Be able to ignore parts of the text
- [x] Ignore front matter
- [x] Update README
- [x] MarkdownCleaner Tests for changes
- [x] Slight refactoring of the Ignore text

#### Cases considered

1. Regular comment: 

`<!-- Regular comment -->`

2. Inline comment: `<!-- Inline comment -->`
3. Multiline comment:

```
Some text <!-- A
multiline
comment --> also here
```

4. Ignore comments:

- Start ignoring lines after: `<!-- textidote: ignore begin -->`
- Stop ignoring lines after: `<!-- textidote: ignore end -->`

5. Ignore front matter: See #179 

---

closes #168 
closes #179 