### PR TITLE
fixed url for ant download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8 AS build
 
-ADD https://downloads.apache.org//ant/binaries/apache-ant-1.10.9-bin.tar.gz /root/ant.tar.gz
+ADD https://downloads.apache.org//ant/binaries/apache-ant-1.10.11-bin.tar.gz /root/ant.tar.gz
 COPY . /build
 WORKDIR /build
 


### PR DESCRIPTION
The ant version referenced in the Dockerfile does not seem to be available anymore. `docker build` fails with a HTTP 404 error because of this. The pull request fixes this by using a higher patch level of ant 1.10.