### PR TITLE
Fix regex to replace \verb command by dummy placeholder

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
@@ -321,8 +321,7 @@ public class LatexCleaner extends TextCleaner
 		// Replace citations by dummy placeholder
 		as_out = as_out.replaceAll("\\\\(cite|citep|citel|parencite|textcite)(\\[.*?\\])*\\{.*?\\}", "[0]");
 		// Replace verbatim by dummy placeholder
-		as_out = as_out.replaceAll("\\\\verb\\+[^\\+]*?\\+", "[0]");
-		as_out = as_out.replaceAll("\\\\verb\"[^\"]*?\"", "[0]");
+		as_out = as_out.replaceAll("\\\\verb\\*?(\\S).*?\\1", "[0]");
 		// Replace references and URLs by dummy placeholder
 		as_out = as_out.replaceAll("\\\\(ref|url|eqref|cref|Cref|vref|Vref|nameref|vpageref|pageref)\\{.*?\\}", "X");
 		// Delete \href command and its url part


### PR DESCRIPTION
+ Closes #208 as [sh:d:002] rule doesn't trigger incorrectly anymore

Ant tests are passing.
Errors are not reported inside \verb commands, but they are correctly reported outside:
![imagen](https://user-images.githubusercontent.com/43813484/184122711-1d9ac0fb-3c56-444d-bf7f-09fa4b5e2a1e.png)