### PR TITLE
Limit number of suggestions to 5

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/rules/CheckLanguage.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/rules/CheckLanguage.java
@@ -229,7 +229,12 @@ public class CheckLanguage extends Rule
 			List<String> replacements = rm.getSuggestedReplacements();
 			if (!replacements.isEmpty())
 			{
-				advice_message.append(". Suggestions: ").append(replacements.toString());
+				List<String> suggestions = replacements.stream().limit(5).collect(Collectors.toList());
+				if (replacements.size() > 5)
+				{
+					suggestions.add("...");
+				}
+				advice_message.append(" Suggestions: ").append(suggestions.toString());
 			}
 			advice_message.append(" (").append(rm.getFromPos()).append(")");
 			Advice ad = new Advice(new CheckLanguageSpecific(rm.getRule().getId(), rm.getRule().getDescription()), r, advice_message.toString(), s, line);


### PR DESCRIPTION
I'm getting the following output:
```
* L73C1-L73C3 Possible spelling mistake found.. Suggestions: [AKO, Ago, Aka, 
  KO, AFO, Ado, AAO, ACO, AEO, AGO, AHO, AIO, AJO, AK, AKB, AKC, AKD, AKE, AKF, 
  AKG, AKJ, AKK, AKL, AKM, AKN, AKP, AKQ, AKR, AKS, AKT, AKU, AKV, AKX, AKY, 
  ALO, AMO, ANO, AO, AOO, APO, ATO, AUO, AVO, AYO, AZO, TKO, A, And, To, As, 
  At, An, Any, Are, Who, All, Two, Age, Go, Make, No, So, Too, OK, UK, Air, 
  Art, Do, Km, Take, Act, Also, Add, Aid, Am, Arm, Lake, Pro, Tho, NATO, Ad, 
  Ask, Asks, Duo, Kg, Sky, AFC, HBO, Rio, Ads, Arc, Ash, Atom, Atop, Auto, 
  Fake, Oak, Sake, Ski, Wake, Zoo, Jake, Jo, SK, WHO, Ace, Aft, Akin, Ate, Bio, 
  Cake, Ego, Quo, ACM, ACS, ADC, ADP, AF, AOL, APA, APC, ATC, ATM, ATV, Afro, 
  Amos, Ana, Avon, CIO, DSO, HK, IPO, KB, Lao, Mao, Mayo, Mk, WTO, Ale, Alto, 
  Amp, Ant, Ape, Apt, Aux, Awe, Halo, Oaks, Ska, Yo, AAU, ADR, AEC, AEG, AIF, 
  AIG, AMX, APG, APS, ARL, ARP, ASB, ASD, Abe, Ada, Akron, Aug, Ava, Baku, CFO, 
  Cato, Eco, FAO, GPO, Geo, IMO, NCO, PKI, PKK, Tao, USO, Waco, Yoko, Ah, Ammo, 
  Ark, Avg, Axon, Bake, Capo, Lakh, Rake, Woo, AAT, ABM, ACU, AD, ADD, ADT, 
  AEF, AFM, AFN, AGC, AGS, AHS, AIT, APD, APM, ARF, ASN, AWOL, Aldo, Apr, Ara, 
  Argo, Arno, Aron, Azov, BMO, CDO, CKD, CPO, CTO, DKK, ESO, FBO, HVO, Iago, 
  KGO, LFO, LSO, MRO, PKP, PSO, PTO, RPO, SFO, Amok, Asp, Av, Ax, Aye, Boo, 
  Emo, Foo, Fro, Goo, Sago, Taro, Yak, ACD, ACG, ACH, AGR, APB, APN, AUT, AZT, 
  Adm, CBO, EKG, GMO, HMO, ICO, Karo, LPO, MCO, MKT, MTO, PKB, SRO, SSO, Saki, 
  Abs, Aim, Aloe, Amt, Ankh, Auks, Coo, Dado, Eke, Taco, Wok, Yaks, FPO, KOB, 
  SKU, TCO, Adj, Aha, Ain, Alp, Anon, Awl, Bro, Faro, Moo, Pk, AHQ, BKS, EEO, 
  Adv, Ail, App, Arks, Avow, Kayo, Pkg, Wacko, MHO, Wyo, Agog, Ahoy, AAA, ABC, 
  AMC, ATP, Afr, Ali, Amy, Ann, CEO, Leo, OKs, UFO, Ave, Mks, Jato, 3DO, A10, 
  A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, 
  A26, A27, A28, A29, A30, A31, A32, A33, A34, A35, A36, A37, A38, A39, A40, 
  A41, A42, A43, A44, A45, A46, A47, A48, A49, A50, A51, A52, A53, A54, A55, 
  A56, A57, A58, A59, A60, A61, A62, A63, A64, A65, A66, A67, A68, A69, A6M, 
  A70, A71, A72, A73, A74, A75, A76, A77, A78, A79, A80, A81, A82, A83, A84, 
  A85, A86, A87, A88, A89, A90, A91, A92, A93, A94, A95, A96, A97, A98, A99, 
  A9C, AA, AAB, AAC, AAD, AAE, AAF, AAG, AAH, AAI, AAJ, AAK, AAL, AAM, AAN, 
  AAP, AAQ, AAR, AAS, AAV, AAW, AAX, AAY, AAZ, AB, ABA, ABB, ABD, ABF, ABG, 
  ABH, ABJ, ABK, ABL, ABN, ABP, ABQ, ABR, ABS, ABT, ABU, ABV, ABW, ABX, ABZ, 
  AC, ACA, ACB, ACC, ACF, ACI, ACJ, ACK, ACL, ACN, ACP, ACR, ACT, ACV, ACW, 
  ACX, ACY, ACZ, ADA, ADB, ADF, ADG, ADH, ADJ, ADK, ADL, ADM, ADN, ADQ, ADS, 
  ADV, ADX, ADY, ADZ, AE, AEA, AEB, AED, AEE, AEI, AEJ, AEK, AEL, AEM, AEMO, 
  AEN, AEP, AEQ, AER, AES, AET, AEU, AEV, AEW, AEX, AEZ, AFA, AFAO, AFB, AFD, 
  AFE, AFF, AFG, AFH, AFI, AFJ, AFK, AFL, AFQ, AFR, AFS, AFT, AFU, AFV, AFW, 
  AFX, AFZ, AG, AGB, AGD, AGE, AGF, AGG, AGH, AGI, AGJ, AGK, AGL, AGM, AGN, 
  AGP, AGQ, AGT, AGU, AGV, AGW, AGX, AGY, AGZ, AHA, AHB, AHC, AHD, AHE, AHF, 
  AHG, AHH, AHI, AHJ, AHK, AHL, AHM, AHN, AHR, AHT, AHU, AHV, AHW, AHX, AHY, 
  AHZ, AI, AIB, AIC, AID, AIE, AIH, AII, AIJ, AIK, AIM, AIP, AIQ, AIS, AIU, 
  AIV, AIW, AIY, AIZ, AIs, AJ, AJB, AJC, AJF, AJG, AJH, AJI, AJJ, AJK, AJL, 
  AJN, AJP, AJQ, AJR, AJS, AJT, AJU, AJV, AJW, AJY, AKFG, AKJQ, AL, ALB, ALC, 
  ALD, ALE, ALG, ALH, ALJ, ALK, ALL, ALM, ALN, ALP, ALQ, ALR, ALS, ALV, ALW, 
  ALX, ALZ, AM, AMA, AMD, AME, AMF, AMG, AMH, AMJ, AMK, AML, AMM, AMN, AMOA, 
  AMOE, AMP, AMQ, AMR, AMS, AMT, AMU, AMV, AMW, AMY, AMZ, AN, ANB, ANC, AND, 
  ANE, ANF, ANFO, ANG, ANH, ANI, ANJ, ANK, ANL, ANM, ANN, ANP, ANQ, ANR, ANS, 
  ANT, ANV, ANW, ANX, ANY, ANZ, AOA, AOB, AOC, AOD, AOE, AOF, AOG, AOH, AOI, 
  AOJ, AOK, AOM, AON, AOP, AOQ, AOR, AOS, AOT, AOU, AOV, AOW, AOX, AP, APE, 
  APF, APH, API, APJ, APK, APL, APP, APQ, APR, APT, APU, APV, APW, APX, APY, 
  APZ, AQA, AQB, AQC, AQF, AQG, AQH, AQI, AQK, AQL, AQM, AQP, AQR, AQS, AQT, 
  AQY, AR, ARB, ARC, ARD, ARE, ARH, ARI, ARJ, ARK, ARM, ARN, ARQ, ARR, ART, 
  ARU, ARV, ARW, ARX, ARY, ASA, ASC, ASE, ASF, ASG, ASH, ASJ, ASK, ASL, ASM, 
  ASP, ASQ, ASR, ASS, AST, ASU, ASV, ASW, ASX, ASY, ASZ, AT, AT3, ATA, ATB, 
  ATD, ATE, ATF, ATG, ATH, ATI, ATK, ATL, ATN, ATQ, ATR, ATS, ATT, ATU, ATW, 
  ATX, ATY, ATZ, AU, AUA, AUC, AUD, AUE, AUF, AUG, AUI, AUJ, AUL, AUM, AUN, 
  AUP, AUQ, AUR, AUS, AUU, AUW, AUX, AUY, AUZ, AV, AVA, AVB, AVC, AVE, AVF, 
  AVG, AVH, AVI, AVK, AVL, AVN, AVP, AVR, AVS, AVU, AVV, AVW, AVX, AVY, AVZ, 
  AWA, AWB, AWD, AWE, AWG, AWK, AWM, AWN, AWP, AWR, AWS, AWU, AWZ, AX, AXB, 
  AXC, AXD, AXG, AXK, AXL, AXM, AXN, AXP, AXR, AXS, AXV, AXX, AYA, AYC, AYD, 
  AYE, AYG, AYH, AYI, AYJ, AYL, AYN, AYP, AYQ, AYR, AYS, AYU, AYY, AYZ, AZ, 
  AZA, AZB, AZD, AZE, AZF, AZI, AZN, AZS, AZW, AZZ, Ac, Ag, Al, Ala, Alpo, Ar, 
  Ats, Au, BACO, BAFO, BBO, BCO, BDO, BEO, BFO, BGO, BHO, BIO, BJO, BKA, BKC, 
  BKD, BKE, BKF, BKH, BKI, BKK, BKL, BKM, BKN, BKP, BKQ, BKR, BKT, BKV, BKW, 
  BKX, BKY, BNO, BO, BPO, BRO, BSO, BTO, BUO, BVO, BXO, BYO, BZO, Biko, Bk, 
  CAK, CAPO, CCO, CGO, CHO, CK, CKB, CKK, CKM, CKR, CKS, CKY, CMO, CNO, CO, 
  CRO, CUO, CVO, CWO, CXO, CZO, Co, DAK, DBO, DCO, DDO, DFO, DJO, DK, DKB, DKP, 
  DKR, DKZ, DMO, DO, DPO, DXO, DZO, EAK, EAO, EK, EKF, ELO, EO, EPO, ERO, FAK, 
  FCO, FFO, FK5, FKK, FKM, FMO, FNO, FO, FRO, FTO, Flo, GAAO, GAO, GK, GKG, 
  GKP, GO, GSO, GTO, Gk, HDO, HKB, HKD, HKG, HKI, HO, HTO, Ho, IAO, IBO, IFO, 
  IKB, ISO, Ibo, Ike, Io, Ito, JAK, JATO, JGO, JKR, JO, JPO, K, K7, KC, KE, KG, 
  KJ, KKK, KKL, KKS, KM, KN, KNO, KOD, KOF, KOH, KOI, KOK, KOP, KOR, KOS, KP, 
  KR, KS, KT, KU, KV, KW, KY, KZ, Kano, Kb, Kr, Ks, Ky, LAK, LBO, LKA, LKM, 
  LNO, LO, MAK, MK, MKB, MKD, MKG, MKM, MKP, MKS, MO, MSO, MYO, Mo, NAO, NIO, 
  NK, NKM, NLO, NO, NPO, NRO, Neo, O, OAO, OBO, OCO, OKF, OLO, OMO, OO, OPO, 
  OTO, Ono, PAIO, PAK, PAO, PDO, PFO, PGO, PIO, PK, PKA, PKD, PKS, PLO, PMO, 
  PO, POO, PPO, PRO, Po, QPO, RGO, RIO, RKA, RKD, RNO, RO, RSO, RTO, SAK, SAO, 
  SCO, SDO, SEO, SKA, SKI, SKK, SKN, SKZ, SLO, SO, STO, Saks, TAO, TK, TKD, 
  TKK, TKL, TKM, TKP, TKS, TKT, TNO, TO, TPO, TSO, TTO, TVO, TYO, UIO, UKR, UO, 
  UQO, UUO, VCO, VMO, VO, WKB, WKT, YCO, YKL, YMO, YTO, YVO, ZKH, ZO, ZRO, Aah, 
  Ab, Alb, Alt, Ang, Ans, Arr, Ass, Auk, Aw, Awn, Ck, Dago, Hake, kW, Kc, Kl, 
  Kn, Kt, Kw, Lo, Loo, Oho, Pkt, Poo, Rho, Wk, 4K, A&A, A&D, A&E, A&M, A&P, 
  A&R, A-OK, ABI, ACE, ACh, ADI, ADU, AFP, AGA, AGs, AIX, ALF, ALU, AMI, AMLO, 
  APKs, APs, ASOS, AVM, AVs, AWC, AWF, AXA, Abi, Abu, Akola, Alok, Aon, AtoZ, 
  Atos, Avvo, CKs, CSO, Calo, DKA, EASO, ECO, GKE, HEO, IGO, JK, Jakob, Jio, 
  KD, KKR, Léo, MKV, MMO, Marko, NAK, NAKs, NGO, NSO, OKR, OOO, P&O, PEO, PKG, 
  PKU, Paco, Pago, QBO, RKI, SJO, São, UNO, Udo, VK, WaPo, Yakov, Aero, Ahh, 
  Ai, Ais, Akçe, Amu, Aww, Axe, Camo, Hào, kJ, kN, Ok, Saké] (5236) 
  [lt:en:MORFOLOGIK_RULE_EN_US] 
  Ako
```

I don't think there is a good reason to display more than 5 or so spelling suggestions because at that point it's bascially just guessing so I added a limit. I also fixed the duplicated dotted in front of "Suggestions".

If desired this limit could be made customizable via a command line argument but that's beyond what I can quickly fix in Java. 