### PR TITLE
Fix: AnnotatedString.getLineOf results in an infinite loop under certain input #224

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/as/AnnotatedString.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/as/AnnotatedString.java
@@ -412,35 +412,30 @@ public class AnnotatedString implements ExplanationQueryable
 
 	/**
 	 * Gets the line of a string containing the n-th character.
+	 * @param s The string to search
 	 * @param index The number of the character
 	 * @return The line
 	 * @throws ArrayIndexOutOfBoundsException If the argument is out of bounds
 	 */
-	/*@ non_null @*/ protected static Line getLineOf(String s, int index) throws ArrayIndexOutOfBoundsException
-	{
+	/*@ non_null @*/ protected static Line getLineOf(String s, int index) throws ArrayIndexOutOfBoundsException {
+		int currentIndex = 0;
+
 		if (index < 0 || index >= s.length())
 		{
-			throw new ArrayIndexOutOfBoundsException("Character " + index + " does not exist");
+			throw new ArrayIndexOutOfBoundsException("Character " + index + " out of bounds");
 		}
-		int pos = 0;
-		while (pos < s.length() && pos < index)
-		{
-			int next_pos = s.indexOf(CRLF, pos);
-			if (next_pos < 0 || next_pos > index)
-			{
-				break;
+
+		for (String line : s.lines().toArray(String[]::new)) {
+			int lineLength = line.length();
+
+			if (currentIndex + lineLength > index) {
+				return new Line(line, currentIndex);
 			}
-			if (next_pos < s.length() && next_pos < index)
-			{
-				pos = next_pos + CRLF_S;
-			}
+
+			currentIndex += lineLength + 1; // add 1 for the newline character(s)
 		}
-		int next_pos = s.indexOf(CRLF, pos);
-		if (next_pos < 0)
-		{
-			return new Line(s.substring(pos), pos);
-		}
-		return new Line(s.substring(pos, next_pos), pos);
+
+		throw new ArrayIndexOutOfBoundsException("Character " + index + " does not exist in string");
 	}
 
 	/**

--- a/Source/Core/src/ca/uqac/lif/textidote/as/AnnotatedString.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/as/AnnotatedString.java
@@ -418,24 +418,20 @@ public class AnnotatedString implements ExplanationQueryable
 	 * @throws ArrayIndexOutOfBoundsException If the argument is out of bounds
 	 */
 	/*@ non_null @*/ protected static Line getLineOf(String s, int index) throws ArrayIndexOutOfBoundsException {
-		int currentIndex = 0;
-
-		if (index < 0 || index >= s.length())
-		{
-			throw new ArrayIndexOutOfBoundsException("Character " + index + " out of bounds");
+		if (index < 0 || index >= s.length()) {
+			throw new ArrayIndexOutOfBoundsException("Character " + index + " does not exist");
 		}
 
-		for (String line : s.lines().toArray(String[]::new)) {
-			int lineLength = line.length();
-
-			if (currentIndex + lineLength > index) {
-				return new Line(line, currentIndex);
-			}
-
-			currentIndex += lineLength + 1; // add 1 for the newline character(s)
+		int startIndex = 0;
+		int endIndex = s.indexOf(CRLF, startIndex);
+		while (endIndex >= 0 && endIndex < index) {
+			startIndex = endIndex + CRLF_S;
+			endIndex = s.indexOf(CRLF, startIndex);
 		}
+		endIndex = (endIndex >= 0) ? endIndex : s.length();
 
-		throw new ArrayIndexOutOfBoundsException("Character " + index + " does not exist in string");
+		String lineText = s.substring(startIndex, endIndex);
+		return new Line(lineText, startIndex);
 	}
 
 	/**

--- a/example.tex
+++ b/example.tex
@@ -64,5 +64,18 @@ Cowtest({
   
 \section{ THIS TITLE IS IN CAPS AND SHOULD NOT}
 
+%%% I noticed these lines caused an infinite loop to occur in textidote
+%%% leaving here for testing purposes:
+
+%%
+%% The "author" command and its associated commands are used to define
+%% the authors and their affiliations.
+%% Of note is the shared affiliation of the first two authors, and the
+%% "authornote" and "authornotemark" commands
+%% used to denote shared contribution to the research.
+\author{Some Author}
+% Specifically, this line:
+\email{asdfgh.zxcvbnm@123.12345678.ca}
+
 \end{document}
 %% :wrap=soft:


### PR DESCRIPTION
There seems to be a few issues with the existing loop in AnnotatedString.getLineOf that can cause it to loop indefinitely. One potential issue is that the condition of the while loop checks for pos < s.length() before pos < index. If index is less than pos, the loop will never terminate because the condition pos < index will always be false.

Another potential issue is that the loop increments pos using pos = next_pos + CRLF_S, but it only does this if next_pos is less than s.length() and next_pos is less than index. If next_pos is equal to index, the loop will never terminate because pos will never be incremented.

For an example line that causes this, see example.tex.

To fix: used newer Java features which cleans up logic of iterating lines in string, the loop will only iterate to a maximum of the strings length before breaking.