### PR TITLE
Remove multiline math environments

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
@@ -345,9 +345,9 @@ public class LatexCleaner extends TextCleaner
 		// Inline display math with only digits and letters
 		as_out = as_out.replaceAll("\\\\\\(([A-Za-z0-9,\\.]*?)\\\\\\)", "$1");
 		// Otherwise, replace by X
-		as_out = as_out.replaceAll("\\\\\\(.*?\\\\\\)", "X");
+		as_out = as_out.replaceAll("(?s)\\\\\\(.*?\\\\\\)", "X");
 		// Equations are removed
-		as_out = as_out.replaceAll("\\\\\\[.*?\\\\\\]", "");
+		as_out = as_out.replaceAll("(?s)\\\\\\[.*?\\\\\\]", "");
 		// Inline equations in old TeX style ("$foo$")
 		as_out = replaceInlineEquations(as_out);
 		/*as_out = as_out.replaceAll("([^\\\\])\\$.*?[^\\\\]\\$", "$1X");

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/LatexCleanerTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/LatexCleanerTest.java
@@ -70,6 +70,21 @@ public class LatexCleanerTest
 	}
 	
 	@Test
+	public void testIssue215() throws TextCleanerException
+	{
+		LatexCleaner detexer = new LatexCleaner();
+		detexer.ignoreEnvironment("tikzpicture");
+		AnnotatedString as = detexer.clean(AnnotatedString.read(new Scanner(LatexCleanerTest.class.getResourceAsStream("data/issue215.tex"))));
+		// Check that tikzpicture environment is removed
+		assertEquals(as.toString().indexOf("tikzpicture"), -1);
+		assertEquals(as.toString().indexOf("draw"), -1);
+		// Check that all math enviroments are removed
+		assertEquals(as.toString().indexOf("\\["), -1);
+		assertEquals(as.toString().indexOf("\\]"), -1);
+		assertEquals(as.toString().indexOf("x"), -1);
+	}
+	
+	@Test
 	public void testRemoveMarkup4() throws TextCleanerException
 	{
 		LatexCleaner detexer = new LatexCleaner().setIgnoreBeforeDocument(false);

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/data/issue215.tex
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/data/issue215.tex
@@ -1,0 +1,14 @@
+\begin{document}
+One line math:
+\[\int_{1}^{2}x \mathrm{d}x}\]
+
+Tikzpicture:
+
+Multi line math:
+\[
+  \int_{1}^{2}x \mathrm{d}x}
+\]
+
+One line math:
+\[\int_{1}^{2}x \mathrm{d}x}\]
+\end{document}


### PR DESCRIPTION
This change allows removing math environments when they are displayed across several lines, i.e.
```
\[
  x + y = 3
\]
```
The current implementation is using `replaceAll` but by default it doesn't match across several lines. The flag `(?s)` enables multiline matching. This should solve #215 and #227.