### PR TITLE
Remove multiline math environments

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
@@ -207,7 +207,7 @@ public class LatexCleaner extends TextCleaner
 	 */
 	protected boolean isEnvironmentStart(/*@ non_null @*/ String line)
 	{
-		if (line.matches(".*\\\\begin\\s*\\{\\s*(align|displaymath|equation|table|tabular|verbatim|lstlisting|IEEEkeywords|figure|wrapfigure|eqnarray|gather).*") || line.matches(".*\\\\\\[[^\\]]*"))
+		if (line.matches(".*\\\\begin\\s*\\{\\s*(align|displaymath|equation|table|tabular|verbatim|lstlisting|IEEEkeywords|figure|wrapfigure|eqnarray|gather).*"))
 		{
 			return true;
 		}
@@ -231,7 +231,7 @@ public class LatexCleaner extends TextCleaner
 	 */
 	protected boolean isEnvironmentEnd(/*@ non_null @*/ String line)
 	{
-		if (line.matches(".*\\\\end\\s*\\{\\s*(align|equation|table|tabular|verbatim|lstlisting|IEEEkeywords|figure|wrapfigure|eqnarray|gather).*") || line.matches(".*\\\\\\].*"))
+		if (line.matches(".*\\\\end\\s*\\{\\s*(align|equation|table|tabular|verbatim|lstlisting|IEEEkeywords|figure|wrapfigure|eqnarray|gather).*"))
 		{
 			return true;
 		}
@@ -345,9 +345,9 @@ public class LatexCleaner extends TextCleaner
 		// Inline display math with only digits and letters
 		as_out = as_out.replaceAll("\\\\\\(([A-Za-z0-9,\\.]*?)\\\\\\)", "$1");
 		// Otherwise, replace by X
-		as_out = as_out.replaceAll("\\\\\\(.*?\\\\\\)", "X");
+		as_out = as_out.replaceAll("(?s)\\\\\\(.*?\\\\\\)", "X");
 		// Equations are removed
-		as_out = as_out.replaceAll("\\\\\\[.*?\\\\\\]", "");
+		as_out = as_out.replaceAll("(?s)\\\\\\[.*?\\\\\\]", "");
 		// Inline equations in old TeX style ("$foo$")
 		as_out = replaceInlineEquations(as_out);
 		/*as_out = as_out.replaceAll("([^\\\\])\\$.*?[^\\\\]\\$", "$1X");

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/LatexCleanerTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/LatexCleanerTest.java
@@ -82,6 +82,11 @@ public class LatexCleanerTest
 		assertEquals(as.toString().indexOf("\\["), -1);
 		assertEquals(as.toString().indexOf("\\]"), -1);
 		assertEquals(as.toString().indexOf("x"), -1);
+		// Check that normal text is still present
+		assertTrue(as.toString().indexOf("One line math:") != -1);
+		assertTrue(as.toString().indexOf("Tikzpicture:") != -1);
+		assertTrue(as.toString().indexOf("Multi line math:") != -1);
+		assertTrue(as.toString().indexOf("Second one line math:") != -1);
 	}
 	
 	@Test

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/LatexCleanerTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/LatexCleanerTest.java
@@ -70,6 +70,21 @@ public class LatexCleanerTest
 	}
 	
 	@Test
+	public void testIssue215() throws TextCleanerException
+	{
+		LatexCleaner detexer = new LatexCleaner();
+		detexer.ignoreEnvironment("tikzpicture");
+		AnnotatedString as = detexer.clean(AnnotatedString.read(new Scanner(LatexCleanerTest.class.getResourceAsStream("data/issue215.tex"))));
+		// Check that tikzpicture environment is removed
+		assertEquals(as.toString().indexOf("tikzpicture"), -1);
+		assertEquals(as.toString().indexOf("draw"), -1);
+		// Check that all math enviroments are removed
+		assertEquals(as.toString().indexOf("\\["), -1);
+		assertEquals(as.toString().indexOf("\\]"), -1);
+		assertEquals(as.toString().indexOf("x"), -1);
+	}
+	
+	@Test
 	public void testRemoveMarkup4() throws TextCleanerException
 	{
 		LatexCleaner detexer = new LatexCleaner().setIgnoreBeforeDocument(false);

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/data/issue215.tex
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/data/issue215.tex
@@ -12,6 +12,6 @@ Multi line math:
   \int_{1}^{2}x \mathrm{d}x}
 \]
 
-One line math:
+Second one line math:
 \[\int_{1}^{2}x \mathrm{d}x}\]
 \end{document}

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/data/issue215.tex
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/data/issue215.tex
@@ -1,0 +1,17 @@
+\begin{document}
+One line math:
+\[\int_{1}^{2}x \mathrm{d}x}\]
+
+Tikzpicture:
+\begin{tikzpicture}
+    \draw (0,0);
+\end{tikzpicture}
+
+Multi line math:
+\[
+  \int_{1}^{2}x \mathrm{d}x}
+\]
+
+One line math:
+\[\int_{1}^{2}x \mathrm{d}x}\]
+\end{document}


### PR DESCRIPTION
This change allows removing math environments correctly when they are displayed across several lines or in a single line, i.e.
```
\[
  x + y = 3
\]
or
\[x + y = 3\]
```
The current implementation has a bug described below. It is also using `replaceAll` but by default it doesn't match across several lines. The flag `(?s)` enables multiline matching. This should solve the bug, and the issues #215 and #227.

## Debugging

To discover what was happening I added some prints in the function `removeEnvironments` for the case in `issue215.tex`:
```
line is end of environment: \[\int_{1}^{2}x \mathrm{d}x}\]
line is start of environment:  \begin{tikzpicture}
line is end of environment:  \end{tikzpicture}
line is start of environment:  \[
line is end of environment:  \]
line is end of environment:  \[\int_{1}^{2}x \mathrm{d}x}\]
```
As you can see the line is detected as end of environment but not as a start, causing a mess. The reason for this is that the regex for `isEnvironmentStart` is not matching when it should. So there are actually two solutions:
- The one I'm proposing here. I find this approach more simple.
- Modifying `isEnvironmentEnd` to also not match for single line equations. But then `\(  \)` would need fixing as well.

