### PR TITLE
Fix accidental modification of original file content

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/Linter.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/Linter.java
@@ -190,7 +190,7 @@ public class Linter
 			{
 				filterAdvice(out_list, r.evaluate(s_decommented));
 			}
-			AnnotatedString s_detexed = m_cleaner.clean(s);
+			AnnotatedString s_detexed = m_cleaner.clean(new AnnotatedString(s));
 			if (s_detexed.toString().trim().isEmpty())
 			{
 				throw new LinterException("No text to analyze. Did you omit --read-all?");

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/MainTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/MainTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.Scanner;
+import java.io.File;
 
 import static org.junit.Assert.*;
 
@@ -283,5 +284,23 @@ public class MainTest
 		assertEquals(2, args.length);
 		assertEquals("--foo", args[0]);
 		assertEquals("Some Thing", args[1]);
+	}
+
+	@Test
+	public void testNoBreakOnHTMLWithDummyReplacement() throws IOException
+	{
+		File replace_file = new File(MainTest.class.getResource("rules/data/replace.txt").getFile());
+		String replace_path = replace_file.getAbsolutePath();
+		InputStream in = MainTest.class.getResourceAsStream("rules/data/test-nobreak.tex");
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		PrintStream out = new PrintStream(baos);
+		int ret_code = Main.mainLoop(new String[] {"--read-all", "--replace", replace_path, "--output", "html"}, in, out, new NullPrintStream());
+		String output = new String(baos.toByteArray());
+		assertNotNull(output);
+		// TODO: Fix non zero return code and uncomment below
+		// assertEquals(0, ret_code);
+		assertFalse(output.trim().isEmpty());
+		// Check that the no break warning is present
+		assertTrue(output.indexOf("<span class=\"highlight")!=-1);
 	}
 }

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/MainTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/MainTest.java
@@ -297,8 +297,7 @@ public class MainTest
 		int ret_code = Main.mainLoop(new String[] {"--read-all", "--replace", replace_path, "--output", "html"}, in, out, new NullPrintStream());
 		String output = new String(baos.toByteArray());
 		assertNotNull(output);
-		// TODO: Fix non zero return code and uncomment below
-		// assertEquals(0, ret_code);
+		assertEquals(1, ret_code);
 		assertFalse(output.trim().isEmpty());
 		// Check that the no break warning is present
 		assertTrue(output.indexOf("<span class=\"highlight")!=-1);

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/rules/data/replace.txt
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/rules/data/replace.txt
@@ -1,0 +1,1 @@
+text	replacement

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/rules/data/test-nobreak.tex
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/rules/data/test-nobreak.tex
@@ -1,0 +1,1 @@
+First line \\ Second line


### PR DESCRIPTION
This bug was causing all warnings to get removed from the html output when a replacement file was specified.
I believe it happens because Linter is applying the cleaner to the input string without copying it first. I added a MWE as a test.  (The test fails without this fix)