### PR TITLE
Increase timeout of testEachLanguage

### DIFF
--- a/Source/CoreTest/src/ca/uqac/lif/textidote/LanguageCodeTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/LanguageCodeTest.java
@@ -76,7 +76,7 @@ public class LanguageCodeTest
 		m_languageCode = language_code;
 	}
 
-	@Test(timeout = 15000)
+	@Test(timeout = 25000)
 	public void testEachLanguage() throws IOException
 	{
 		InputStream in = LanguageCodeTest.class.getResourceAsStream("rules/data/test1.tex");


### PR DESCRIPTION
This test is timing out in the workflow very often. For the last commit (27011d9), it ran successfully as a PR but failed later when it was pushed.