### PR TITLE
Add flalign and multline to removable environments

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
@@ -207,7 +207,7 @@ public class LatexCleaner extends TextCleaner
 	 */
 	protected boolean isEnvironmentStart(/*@ non_null @*/ String line)
 	{
-		if (line.matches(".*\\\\begin\\s*\\{\\s*(align|displaymath|equation|table|tabular|verbatim|lstlisting|IEEEkeywords|figure|wrapfigure|eqnarray|gather).*"))
+		if (line.matches(".*\\\\begin\\s*\\{\\s*(align|displaymath|equation|table|tabular|verbatim|lstlisting|IEEEkeywords|figure|wrapfigure|eqnarray|gather|flalign|multline).*"))
 		{
 			return true;
 		}
@@ -231,7 +231,7 @@ public class LatexCleaner extends TextCleaner
 	 */
 	protected boolean isEnvironmentEnd(/*@ non_null @*/ String line)
 	{
-		if (line.matches(".*\\\\end\\s*\\{\\s*(align|equation|table|tabular|verbatim|lstlisting|IEEEkeywords|figure|wrapfigure|eqnarray|gather).*"))
+		if (line.matches(".*\\\\end\\s*\\{\\s*(align|equation|table|tabular|verbatim|lstlisting|IEEEkeywords|figure|wrapfigure|eqnarray|gather|flalign|multline).*"))
 		{
 			return true;
 		}

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/LatexCleanerTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/LatexCleanerTest.java
@@ -286,6 +286,24 @@ public class LatexCleanerTest
 	}
 	
 	@Test
+	public void testRemoveFlalign() throws TextCleanerException
+	{
+		LatexCleaner detexer = new LatexCleaner();
+		detexer.setIgnoreBeforeDocument(false);
+		AnnotatedString as = detexer.clean(AnnotatedString.read(new Scanner("\\begin{flalign}x=b^2-\\sqrt(2a-b)\\end{flalign}")));
+		assertEquals("", as.toString());
+	}
+	
+	@Test
+	public void testRemoveMultline() throws TextCleanerException
+	{
+		LatexCleaner detexer = new LatexCleaner();
+		detexer.setIgnoreBeforeDocument(false);
+		AnnotatedString as = detexer.clean(AnnotatedString.read(new Scanner("test:\n\\begin{multline}x=b^2-\\sqrt(2a-b)\\end{multline}")));
+		assertEquals("test:\n", as.toString());
+	}
+	
+	@Test
 	public void testRemoveLabels1() throws TextCleanerException
 	{
 		LatexCleaner detexer = new LatexCleaner();


### PR DESCRIPTION
Ignores some common math environments. Should address #228.