### PR TITLE
Replace deprecated <tt> with <code> in javadocs

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/Linter.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/Linter.java
@@ -122,7 +122,7 @@ public class Linter
 	/**
 	 * Adds a list of rule IDs to ignore
 	 * @param list The list of rule IDs to ignore. IDs can also contain the
-	 * wildcard character <tt>*</tt>; this can be used to ignore multiple
+	 * wildcard character <code>*</code>; this can be used to ignore multiple
 	 * rules at once.
 	 * @return This linter
 	 */
@@ -145,7 +145,7 @@ public class Linter
 	/**
 	 * Gets all the rules whose name matches a pattern.
 	 * @param rule_pattern The pattern. The only special character allowed is
-	 * the wildcard (<tt>*</tt>), which can match zero or more arbitrary
+	 * the wildcard (<code>*</code>), which can match zero or more arbitrary
 	 * characters in the rule's name.
 	 * @return The list of rules matching the pattern
 	 */

--- a/Source/Core/src/ca/uqac/lif/textidote/Main.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/Main.java
@@ -868,7 +868,7 @@ public class Main
 	 * Reads command-line arguments from a file.
 	 * @param scanner A scanner open on the file to read from
 	 * @return An array of strings, similar to what would be in the
-	 * <tt>args</tt> input of the {@link #main(String[])} method if the
+	 * <code>args</code> input of the {@link #main(String[])} method if the
 	 * arguments were received from the command line.
 	 */
 	/* This method has protected visibility in order to
@@ -922,7 +922,7 @@ public class Main
 	}
 
 	/**
-	 * Adds filenames found in the <tt>input</tt> statements of the current
+	 * Adds filenames found in the <code>input</code> statements of the current
 	 * file to the queue of files to process. A filename is added to the
 	 * queue only if it has not already been processed earlier in the current
 	 * run of the program.

--- a/Source/Core/src/ca/uqac/lif/textidote/as/AnnotatedString.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/as/AnnotatedString.java
@@ -79,13 +79,13 @@ import ca.uqac.lif.petitpoucet.function.strings.Substring;
  * </pre>
  * (Note that contrary to a classical String, where transformations return a
  * new object, here operations mutate and return the <em>current</em> object.)
- * The call to <tt>println</tt> produces "ld abc", as expected. The call to
+ * The call to <code>println</code> produces "ld abc", as expected. The call to
  * {@link #findOriginalIndex(int) findOriginalIndex} then asks the object to
  * retrace the location, in the initial contents of the string, of the
  * character that is currently at index 1. This is letter "d", and we know
- * from the operations we applied to <tt>s</tt> that this "d" corresponds to
+ * from the operations we applied to <code>s</code> that this "d" corresponds to
  * the end of "world" in the original string (underlined in the code above).
- * Thus, the value of <tt>x</tt> is 10, the index of that letter in the
+ * Thus, the value of <code>x</code> is 10, the index of that letter in the
  * original string.
  * <p>
  * This mechanism can exhibit complex behavior. Consider for example the
@@ -113,7 +113,7 @@ import ca.uqac.lif.petitpoucet.function.strings.Substring;
  * <pre>
  * List&lt;Range&gt; ranges = s.invert(8, 24);</pre>
  * 
- * Method <tt>invert</tt> outputs a list of ranges. The previous call asks for
+ * Method <code>invert</code> outputs a list of ranges. The previous call asks for
  * the original character ranges associated to the portion "oranges and apples"
  * of the string. It produces in return these <em>two</em> ranges: [19-25] and
  * [8-13], correctly corresponding to the initial location of "apples" and
@@ -124,12 +124,12 @@ import ca.uqac.lif.petitpoucet.function.strings.Substring;
  * A few corner cases must be considered:
  * <ul>
  * <li>For parts of the replacement string that are outside of a capture group
- * (and hence do not come from the input string), the best <tt>invert</tt> can
+ * (and hence do not come from the input string), the best <code>invert</code> can
  * do is to point to the range that matches the pattern as a whole. Therefore,
- * <tt>s.invert(16, 17)</tt> (location of the word "or") outputs the single
+ * <code>s.invert(16, 17)</code> (location of the word "or") outputs the single
  * range [8,25].</li>
- * <li>For an input range <tt>r</tt> where <tt>invert</tt> returns multiple
- * ranges, the call to {@link #findOriginalRange(Range)} on <tt>r</tt> returns
+ * <li>For an input range <code>r</code> where <code>invert</code> returns multiple
+ * ranges, the call to {@link #findOriginalRange(Range)} on <code>r</code> returns
  * the range that includes them all. In the previous example, this would
  * correspond to the range [8,25].</li>
  * <li>Methods {@link #findOriginalIndex(int)} and
@@ -261,8 +261,8 @@ public class AnnotatedString implements ExplanationQueryable
 	/**
 	 * Determines if the string contains a pattern.
 	 * @param pattern The pattern to look for
-	 * @return <tt>true</tt> if the pattern is found in the string,
-	 * <tt>false</tt> otherwise
+	 * @return <code>true</code> if the pattern is found in the string,
+	 * <code>false</code> otherwise
 	 */
 	/*@ pure @*/ public boolean contains(String pattern)
 	{
@@ -299,7 +299,7 @@ public class AnnotatedString implements ExplanationQueryable
 	 * occurrence of the specified substring.
 	 * @param s The substring
 	 * @return The position of the starting character of the substring, or
-	 * <tt>null</tt> if the substring is not found
+	 * <code>null</code> if the substring is not found
 	 */
 	/*@ pure null @*/ public Position positionOf(String s)
 	{
@@ -323,7 +323,7 @@ public class AnnotatedString implements ExplanationQueryable
 	 * occurrence of the specified substring.
 	 * @param s The substring
 	 * @return The position of the starting character of the substring, or
-	 * <tt>null</tt> if the substring is not found
+	 * <code>null</code> if the substring is not found
 	 */
 	/*@ pure null @*/ public Position lastPositionOf(String s)
 	{
@@ -557,7 +557,7 @@ public class AnnotatedString implements ExplanationQueryable
 	 * Gets the two-dimensional position corresponding to a linear character
 	 * index in the string.
 	 * @param index The character index
-	 * @return The position, or <tt>null</tt> if the index is out of bounds
+	 * @return The position, or <code>null</code> if the index is out of bounds
 	 */
 	/*@ pure null @*/ public Position getPosition(int index)
 	{
@@ -568,7 +568,7 @@ public class AnnotatedString implements ExplanationQueryable
 	 * Gets the two-dimensional position of the <em>original</em> string
 	 * corresponding to a linear character index in the string.
 	 * @param index The character index
-	 * @return The position, or <tt>null</tt> if the index is out of bounds
+	 * @return The position, or <code>null</code> if the index is out of bounds
 	 */
 	/*@ pure null @*/ public Position getOriginalPosition(int index)
 	{
@@ -579,7 +579,7 @@ public class AnnotatedString implements ExplanationQueryable
 	 * Gets the two-dimensional position of the <em>original</em> string
 	 * corresponding to a line/column position in the current string.
 	 * @param p The position
-	 * @return The position, or <tt>null</tt> if the index is out of bounds
+	 * @return The position, or <code>null</code> if the index is out of bounds
 	 */
 	/*@ pure null @*/ public Position findOriginalPosition(Position p)
 	{
@@ -652,7 +652,7 @@ public class AnnotatedString implements ExplanationQueryable
 	 * the current string. If this range corresponds to multiple original ranges,
 	 * a single range encompassing all of them is returned.
 	 * @param r The range in the current string
-	 * @return The range in the original string, or <tt>null</tt>
+	 * @return The range in the original string, or <code>null</code>
 	 * if no range could be found.
 	 */
 	/*@ pure null @*/ public Range findOriginalRange(Range r)
@@ -667,7 +667,7 @@ public class AnnotatedString implements ExplanationQueryable
 	 * a single range encompassing all of them is returned.
 	 * @param start The start of the range
 	 * @param end The end of the range
-	 * @return The range in the original string, or <tt>null</tt>
+	 * @return The range in the original string, or <code>null</code>
 	 * if no range could be found.
 	 */
 	/*@ pure null @*/ public Range findOriginalRange(int start, int end)
@@ -680,7 +680,7 @@ public class AnnotatedString implements ExplanationQueryable
 	 * the original string. If this range corresponds to multiple current ranges,
 	 * a single range encompassing all of them is returned.
 	 * @param r The range in the original string
-	 * @return The range in the current string, or <tt>null</tt>
+	 * @return The range in the current string, or <code>null</code>
 	 * if no range could be found.
 	 */
 	/*@ pure null @*/ public Range findCurrentRange(Range r)
@@ -695,7 +695,7 @@ public class AnnotatedString implements ExplanationQueryable
 	 * a single range encompassing all of them is returned.
 	 * @param start The start of the range
 	 * @param end The end of the range
-	 * @return The range in the current string, or <tt>null</tt>
+	 * @return The range in the current string, or <code>null</code>
 	 * if no range could be found.
 	 */
 	/*@ pure null @*/ public Range findCurrentRange(int start, int end)

--- a/Source/Core/src/ca/uqac/lif/textidote/as/AnnotatedString.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/as/AnnotatedString.java
@@ -95,8 +95,8 @@ import ca.uqac.lif.petitpoucet.function.strings.Substring;
  *   new AnnotatedString("Compare apples and oranges, kiwis and cherries.")
  *       .replaceAll("(.*?) and (.*?)", "$2 or $1");
  * </pre>
- * The result of this code is the string <tt>"Compare oranges or apples,
- * cherries or kiwis."</tt> The capture groups in the regex pattern are
+ * The result of this code is the string <code>"Compare oranges or apples,
+ * cherries or kiwis."</code> The capture groups in the regex pattern are
  * correctly tracked, so that:
  * 
  * <pre>Range r = s.findOriginalRange(8, 14);</pre>

--- a/Source/Core/src/ca/uqac/lif/textidote/as/RangeFetcher.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/as/RangeFetcher.java
@@ -73,7 +73,7 @@ class RangeFetcher extends Crawler
 	/**
 	 * Determines if a node is a leaf PartNode.
 	 * @param n The node
-	 * @return <tt>true</tt> if n is a part node and a leaf, <tt>false</tt>
+	 * @return <code>true</code> if n is a part node and a leaf, <code>false</code>
 	 * otherwise
 	 */
 	protected static boolean isLeaf(/*@ non_null @*/ Node n)

--- a/Source/Core/src/ca/uqac/lif/textidote/cleaning/TextCleaner.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/cleaning/TextCleaner.java
@@ -70,7 +70,7 @@ public abstract class TextCleaner
 	/**
 	 * Returns the list of inner files included in the file to be cleaned.
 	 * Currently, this only has a meaning for cleaners based on LaTeX,
-	 * which has <tt>include</tt> and <tt>input</tt> instructions.
+	 * which has <code>include</code> and <code>input</code> instructions.
 	 * This result will be non-empty only after
 	 * {@link #clean(AnnotatedString) clean()} has been called.
 	 * @return The list of filenames

--- a/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
@@ -38,7 +38,7 @@ public class LatexCleaner extends TextCleaner
 
 	/**
 	 * Whether the detexer will remove all lines before seeing
-	 * <tt>\begin{document}</tt>
+	 * <code>\begin{document}</code>
 	 */
 	protected boolean m_ignoreBeforeDocument = true;
 
@@ -53,13 +53,13 @@ public class LatexCleaner extends TextCleaner
 	/*@ non_null @*/ protected final Set<String> m_macrosToIgnore = new HashSet<String>();
 
 	/**
-	 * A list of <em>non-commented</em> <tt>input</tt> and <tt>include</tt>
+	 * A list of <em>non-commented</em> <code>input</code> and <code>include</code>
 	 * declarations found in the file to be cleaned.
 	 */
 	protected final List<String> m_innerFiles = new ArrayList<String>();
 
 	/**
-	 * A regex pattern matching the <tt>input</tt> and <tt>include</tt>
+	 * A regex pattern matching the <code>input</code> and <code>include</code>
 	 * declarations in a line of markup.
 	 */
 	protected static final transient Pattern m_includePattern = Pattern.compile("^.*\\\\(input|include)\\s*\\{(.*?)\\}.*$");
@@ -505,7 +505,7 @@ public class LatexCleaner extends TextCleaner
 
 	/**
 	 * Sets whether the detexer will remove all lines before seeing
-	 * <tt>\begin{document}</tt>, without even attempting to interpret
+	 * <code>\begin{document}</code>, without even attempting to interpret
 	 * them
 	 * @param b Set to {@code true} to remove the lines (the default),
 	 * {@code false} otherwise
@@ -518,8 +518,8 @@ public class LatexCleaner extends TextCleaner
 	}
 
 	/**
-	 * Populates a list of <em>non-commented</em> <tt>input</tt> and
-	 * <tt>include</tt> declarations found in the file to be cleaned.
+	 * Populates a list of <em>non-commented</em> <code>input</code> and
+	 * <code>include</code> declarations found in the file to be cleaned.
 	 * @param as The contents of the file (where environments and
 	 * comments have already been removed).
 	 */
@@ -542,8 +542,8 @@ public class LatexCleaner extends TextCleaner
 	}
 
 	/**
-	 * Returns the list of <em>non-commented</em> <tt>input</tt> and
-	 * <tt>include</tt> declarations found in the file to be cleaned.
+	 * Returns the list of <em>non-commented</em> <code>input</code> and
+	 * <code>include</code> declarations found in the file to be cleaned.
 	 * This result will be non-empty only after
 	 * {@link #clean(AnnotatedString) clean()} has been called.
 	 * @return The list of filenames

--- a/Source/Core/src/ca/uqac/lif/textidote/rules/CheckCaptions.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/rules/CheckCaptions.java
@@ -31,7 +31,7 @@ import ca.uqac.lif.textidote.as.Position;
  * Checks that captions end with a period. This rule does not evaluate a
  * regular expression, as the nesting of commands within the caption creates
  * lots of false positives. Rather, it finds an occurrence of
- * <tt>\caption</tt>, and then keeps track of the nesting level of opening
+ * <code>\caption</code>, and then keeps track of the nesting level of opening
  * and closing braces.
  * 
  * @author Sylvain Hallé

--- a/Source/Core/src/ca/uqac/lif/textidote/rules/CheckCiteMix.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/rules/CheckCiteMix.java
@@ -27,8 +27,8 @@ import ca.uqac.lif.textidote.as.AnnotatedString;
 import ca.uqac.lif.textidote.as.Match;
 
 /**
- * Checks that a document does not mix occurrences of <tt>\cite</tt>
- * and <tt>\citep</tt>/<tt>\citet</tt>. * 
+ * Checks that a document does not mix occurrences of <code>\cite</code>
+ * and <code>\citep</code>/<code>\citet</code>. * 
  * @author Sylvain Hallé
  *
  */

--- a/Source/Core/src/ca/uqac/lif/textidote/rules/CheckFigurePaths.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/rules/CheckFigurePaths.java
@@ -34,13 +34,13 @@ import ca.uqac.lif.textidote.as.AnnotatedString.Line;
  * <p>
  * For the means of this rule, an absolute path is anything of the form
  * <ul>
- * <li><tt>X:...</tt> (Windows drive letter)</li>
- * <li><tt>/...</tt> (Unix absolute path)</li>
- * <li>anything that contains <tt>..</tt> (moving up in the folder
+ * <li><code>X:...</code> (Windows drive letter)</li>
+ * <li><code>/...</code> (Unix absolute path)</li>
+ * <li>anything that contains <code>..</code> (moving up in the folder
  * structure is not recommended)</li>
  * </ul>
  * Formally, this rule checks that no such path appears in an
- * <tt>\includegraphics</tt> command.
+ * <code>\includegraphics</code> command.
  * 
  * @author Sylvain Hallé
  *

--- a/Source/Core/src/ca/uqac/lif/textidote/rules/CheckFigureReferences.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/rules/CheckFigureReferences.java
@@ -34,9 +34,9 @@ import ca.uqac.lif.textidote.as.AnnotatedString.Line;
  * Checks that every figure with a label is mentioned in the text
  * at least once.
  * <p>
- * Formally, this rule checks that for every occurrence of <tt>\label{X}</tt>
- * within a <tt>figure</tt> environment (that is not commented out), there
- * exists a <tt>\ref{X}</tt> somewhere in the text (that is not commented
+ * Formally, this rule checks that for every occurrence of <code>\label{X}</code>
+ * within a <code>figure</code> environment (that is not commented out), there
+ * exists a <code>\ref{X}</code> somewhere in the text (that is not commented
  * out).
  * 
  * @author Sylvain Hallé


### PR DESCRIPTION
At the moment `ant javadoc` generates 53 errors and 9 warnings. This PR uses `<code>` instead of `<tt>`, as `<tt>` is not supported by html5.
The command used to generate it is:

`find Source -type f -name "*.java" -exec sed -i 's/<tt>\([^<]*\)<\/tt>/<code>\1<\/code>/g' {} \;`


After this PR there are only 6 errors and 9 warnings.

Example before change:
<img width="1678" alt="Screenshot 2023-10-24 at 11 33 35" src="https://github.com/sylvainhalle/textidote/assets/5374768/7b92f252-5329-4525-9187-3399e7e271d3">

After change: (they look the same)
<img width="1684" alt="Screenshot 2023-10-24 at 11 34 59" src="https://github.com/sylvainhalle/textidote/assets/5374768/9474ea79-c325-4219-af2f-8d8b08229164">

