### PR TITLE
Allow replacing with nothing in replacements file

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/cleaning/ReplacementCleaner.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/cleaning/ReplacementCleaner.java
@@ -100,12 +100,12 @@ public class ReplacementCleaner extends TextCleaner
 		while (scanner.hasNextLine())
 		{
 			String line = scanner.nextLine();
-			if (line.startsWith("#") || line.trim().isEmpty())
+			if (line.trim().startsWith("#") || line.trim().isEmpty())
 			{
 				// Ignore
 				continue;
 			}
-			String[] parts = line.split("\\t+");
+			String[] parts = line.split("\\t", 2);
 			if (parts.length != 2)
 			{
 				// Malformed line: ignore

--- a/Source/Core/src/ca/uqac/lif/textidote/cleaning/ReplacementCleaner.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/cleaning/ReplacementCleaner.java
@@ -105,7 +105,7 @@ public class ReplacementCleaner extends TextCleaner
 				// Ignore
 				continue;
 			}
-			String[] parts = line.split("\\t", 2);
+			String[] parts = line.split("\\t+", 2);
 			if (parts.length != 2)
 			{
 				// Malformed line: ignore

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/LatexCleanerTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/LatexCleanerTest.java
@@ -389,6 +389,14 @@ public class LatexCleanerTest
 		AnnotatedString as = cleaner.clean(AnnotatedString.read(new Scanner("foo")));
 		assertEquals("bar", as.toString());
 	}
+
+	@Test
+	public void testReplaceWithNothing() throws TextCleanerException
+	{
+		ReplacementCleaner cleaner = ReplacementCleaner.create(new Scanner(LatexCleanerTest.class.getResourceAsStream("data/replace-with-nothing.txt")));
+		AnnotatedString as = cleaner.clean(AnnotatedString.read(new Scanner("this is a text to be replaced")));
+		assertEquals("this is a  to be replaced", as.toString());
+	}
 	
 	@Test
 	public void testReplacementCleaner2() throws TextCleanerException

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/data/replace-with-nothing.txt
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/data/replace-with-nothing.txt
@@ -1,2 +1,2 @@
  # commment
-text	
+text			

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/data/replace-with-nothing.txt
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/data/replace-with-nothing.txt
@@ -1,0 +1,2 @@
+ # commment
+text	


### PR DESCRIPTION
This fix should address #173, happening when the user wants to remove a given string from the input. In such case they can now write a single line in the replacement file containing:
`<regex_to_be_removed><TAB>`
The fix uses the additional `limit` argument to the split function (explained [here](https://stackoverflow.com/a/14602089)), such that in the case mentioned it actually adds an empty string in the `parts` variable. This achieves the desired behaviour without adding additional spaces as can be seen in the test.

There is also a minor change to comment parsing which I think makes it more intuitive.
