### PR TITLE
Add --root argument and %!TEX root support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -289,6 +289,10 @@ file and give you no advice.
 
 TeXtidote also automatically follows sub-files that are embedded from a main document using `\input{filename}` and `\include{filename}` (braces are mandatory). Any such *non-commented* instruction will add the corresponding filename to the running queue. If you want to *exclude* an `\input` from being processed, you must surround the line with `ignore begin`/`end` comments (see below, *Helping TeXtidote*).
 
+TeXtidote takes into account the `%!TEX root = ...` directive for following sub-files. You can also use `--root` argument to specify it separatedly.
+However, if your usecase requires a more complex handling of sub-files you can use many of the available tools to pre-process your project. Some
+suggestions are listed [here](https://tex.stackexchange.com/questions/21838/replace-inputfilex-by-the-content-of-filex-automatically/377404).
+
 ### Removing markup
 
 You can also use TeXtidote just to remove the markup from your original LaTeX

--- a/Source/Core/src/ca/uqac/lif/textidote/Main.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/Main.java
@@ -925,7 +925,7 @@ public class Main
 	}
 	
 	/**
-	 * ACalculate the location of the root dir, using the root if is provided.
+	 * Calculate the location of the root dir, using the root if is provided.
 	 * Otherwise just use the current file location.
 	 * @param current_filename The name of the file currently being processed
 	 * @param root The file of the root document

--- a/Source/Core/src/ca/uqac/lif/textidote/Main.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/Main.java
@@ -203,6 +203,7 @@ public class Main
 		cli_parser.addArgument(new Argument().withLongName("ci").withDescription("Ignores the return code for CI usage"));
 		cli_parser.addArgument(new Argument().withLongName("encoding").withArgument("x").withDescription("Read files using encoding x"));
 		cli_parser.addArgument(new Argument().withLongName("single-file").withDescription("Don't read sub-files if any"));
+		cli_parser.addArgument(new Argument().withLongName("root").withArgument("file").withDescription("Manually set the root of the LaTeX document"));
 
 		// Check if we are using textidote in a CI tool
 		boolean usingCI = false;
@@ -683,7 +684,7 @@ public class Main
 				int added = 0;
 				if (!single_file)
 				{
-					added = addInnerFilesToQueue(c_cleaner.getInnerFiles(), processed_filenames, filename_queue, top_level_filename);
+					added = addInnerFilesToQueue(c_cleaner.getInnerFiles(), processed_filenames, filename_queue, top_level_filename, map.getOptionValue("root"));
 				}
 				if (added > 0 && cmd_filenames.size() > 1)
 				{
@@ -932,13 +933,18 @@ public class Main
 	 * This object is modified by the current method (new filenames can be
 	 * added to it).
 	 * @param current_filename The name of the file currently being processed
+	 * @param root The file of the root document
 	 * @return The number of new files added to the queue
 	 */
 	protected static int addInnerFilesToQueue(List<String> inner_files, Set<String> processed_filenames,
-			Queue<String> file_queue, String current_filename)
+			Queue<String> file_queue, String current_filename, /*@ nullable @*/ String root)
 	{
 		int added = 0;
-		File f = new File(current_filename);
+		String parent = root;
+		if (root == null){
+			parent = current_filename;
+		}
+		File f = new File(parent);
 		String parent_path = f.getParent();
 		if (parent_path == null)
 		{

--- a/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
@@ -155,7 +155,7 @@ public class LatexCleaner extends TextCleaner
 		new_as = removeEnvironments(new_as);
 		new_as = removeMacros(new_as);
 		fetchIncludes(new_as, root);
-		//new_as = removeAllMarkup(new_as);	
+		//new_as = removeAllMarkup(new_as);
 		new_as = removeMarkup(new_as);
 		//new_as = simplifySpaces(new_as);
 		return new_as;

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/MainTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/MainTest.java
@@ -302,4 +302,34 @@ public class MainTest
 		// Check that the no break warning is present
 		assertTrue(output.indexOf("<span class=\"highlight")!=-1);
 	}
+
+	@Test
+	public void testIncludeWithRoot() throws IOException
+	{
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		PrintStream out = new PrintStream(baos);
+		int ret_code = Main.mainLoop(new String[] {"--read-all", "--output", "html", "rules/data/childs/child-section.tex"}, null, out, new NullPrintStream(), MainTest.class);
+		String output = new String(baos.toByteArray());
+		assertNotNull(output);
+		assertEquals(0, ret_code);
+		assertFalse(output.trim().isEmpty());
+		// Check that the desired sections are present
+		assertTrue(output.indexOf("child section")!=-1);
+		assertTrue(output.indexOf("child sibling section")!=-1);
+	}
+
+	@Test
+	public void testIncludeWithRootAsArgument() throws IOException
+	{
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		PrintStream out = new PrintStream(baos);
+		int ret_code = Main.mainLoop(new String[] {"--read-all", "--output", "html", "--root", "rules/data/root.tex", "rules/data/childs/child-section-no-root.tex"}, null, out, new NullPrintStream(), MainTest.class);
+		String output = new String(baos.toByteArray());
+		assertNotNull(output);
+		assertEquals(0, ret_code);
+		assertFalse(output.trim().isEmpty());
+		// Check that the desired sections are present
+		assertTrue(output.indexOf("child section")!=-1);
+		assertTrue(output.indexOf("child sibling section")!=-1);
+	}
 }

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/rules/data/childs/child-section-no-root.tex
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/rules/data/childs/child-section-no-root.tex
@@ -1,0 +1,2 @@
+This is the child section.
+\include{childs/child-sibling}

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/rules/data/childs/child-section.tex
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/rules/data/childs/child-section.tex
@@ -1,0 +1,4 @@
+%!TEX root = ../root.tex
+
+This is the child section.
+\include{childs/child-sibling}

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/rules/data/childs/child-sibling.tex
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/rules/data/childs/child-sibling.tex
@@ -1,0 +1,3 @@
+%!TEX root = ../root.tex
+
+This is the child sibling section.

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/rules/data/root.tex
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/rules/data/root.tex
@@ -1,0 +1,5 @@
+\begin{document}
+\section{Introduction}
+
+\include{childs/child_section}
+\end{document}


### PR DESCRIPTION
This should address #131 following the suggested approach in [this comment](https://github.com/sylvainhalle/textidote/issues/131#issuecomment-701381394), that is:

> - Leave the basic sub-file behavior as it is now
> - Add support for the !TEX root magic comment (https://github.com/sylvainhalle/textidote/issues/81#issuecomment-518738197) so that one can check sub-files individually
> - Add the --root file.tex command line option that does the same thing
> - In the Readme, refer users to the tools mentioned in the SO thread if this behavior is not enough for them


## Implementation details

- When using the `%!TEX root` directive, the path provided should be treated as relative to the current file.
- When using the `--root` argument, the path provided should be treated relative to the working directory.

Hence the implementation of these two features are a bit different.

### Corner case
Due to the current logic if you for example supply both `%!TEX root = ../root.tex` and `--root dir/root.tex` options, it might generate incorrect paths: `dir/../child.tex`. But I don't think this should happen often. I can add additional logic to ignore the `%!TEX root` if `--root` is supplied, but is it necessary? There's no need to supply `--root` if the directives are present.