### PR TITLE
Add (failing) test for replaceInlineEquations

### DIFF
--- a/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/LatexCleanerTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/cleaning/LatexCleanerTest.java
@@ -27,6 +27,7 @@ import java.util.Scanner;
 
 import org.junit.Test;
 
+import ca.uqac.lif.petitpoucet.function.strings.Range;
 import ca.uqac.lif.textidote.as.AnnotatedString;
 import ca.uqac.lif.textidote.as.Position;
 import ca.uqac.lif.textidote.cleaning.latex.LatexCleaner;
@@ -463,5 +464,17 @@ public class LatexCleanerTest
 		assertEquals(1, inner_files.size());
 		String s_file = inner_files.get(0);
 		assertEquals("foo.tex", s_file);
+	}
+	
+	@Test
+	public void testInlineEquations() throws TextCleanerException
+	{
+		LatexCleaner detexer = new LatexCleaner();
+		detexer.setIgnoreBeforeDocument(false);
+		AnnotatedString original = AnnotatedString.read(new Scanner("$\\frac{x}{y}$ $x*$"));
+		AnnotatedString as = detexer.clean(new AnnotatedString(original));
+		assertEquals("X X", as.toString());	
+		Range orig_range = as.findOriginalRange(new Range(0, as.length()-1));
+		assertEquals(new Range(0, original.length()-1), orig_range);
 	}
 }


### PR DESCRIPTION
There's something strange happening when replacing inline equations, I add a failing test for this. It might be related to the `AnnotatedString` class. The produced range of the advice is not correct:

<img width="286" alt="Screenshot 2023-10-28 at 12 47 34" src="https://github.com/sylvainhalle/textidote/assets/5374768/3b50ee2e-488e-45b2-91c6-37c8714b07f2">

The suggestion should cover the whole string (because this is cleaned to `X X`, and spell checking warns about repeated words).
This is happening because the range containing the whole cleaned string is not mapping to the whole original string, as it should be. Any ideas of what's wrong?

The test fails with:
`AssertionError: expected:<I0-17> but was:<I7-17>`

(which can be seen in the screenshot)