### PR TITLE
Fix all java-doc errors and warnings

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/Advice.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/Advice.java
@@ -82,8 +82,6 @@ public class Advice implements Comparable<Advice>
 	 * @param resource The resource (e.g. filename) this
 	 * advice refers to
 	 * @param line The line of text on which the advice applies
-	 * @param offset The position (in characters from the beginning of the
-	 * text) where this advice starts
 	 */
 	public Advice(/*@ non_null @*/ Rule rule, /*@ non_null @*/ Range range, 
 			/*@ non_null @*/ String message, /*@ non_null @*/ AnnotatedString resource,

--- a/Source/Core/src/ca/uqac/lif/textidote/as/AnnotatedString.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/as/AnnotatedString.java
@@ -50,7 +50,7 @@ import ca.uqac.lif.petitpoucet.function.strings.Substring;
  * An annotated string is distinct from a regular character {@link String}
  * in a number of aspects.
  * 
- * <h4>Lines</h4>
+ * <h2>Lines</h2>
  * 
  * First, if supports operations addressing characters either in terms of a
  * linear index (offset from the start of the string), or as a line/column
@@ -61,7 +61,7 @@ import ca.uqac.lif.petitpoucet.function.strings.Substring;
  * {@link #getLineOf(int) getLineOf} extracts the text line containing a given
  * index or position.
  * 
- * <h4>Character tracking</h4>
+ * <h2>Character tracking</h2>
  * 
  * An annotated string supports typical methods for string manipulation
  * (e.g. {@link #substring(int) substring},
@@ -375,6 +375,7 @@ public class AnnotatedString implements ExplanationQueryable
 
 	/**
 	 * Gets the n-th line of a string.
+	 * @param s The string to get the line from
 	 * @param line_nb The number of the line
 	 * @return The line
 	 * @throws ArrayIndexOutOfBoundsException If the argument is out of bounds
@@ -497,7 +498,7 @@ public class AnnotatedString implements ExplanationQueryable
 	/**
 	 * Gets the linear index in the original string of a given index
 	 * in the current string contents.
-	 * @param p The position
+	 * @param index The position
 	 * @return The index in the original string
 	 */
 	/*@ pure @*/ public int findOriginalIndex(int index)
@@ -747,8 +748,8 @@ public class AnnotatedString implements ExplanationQueryable
 	 * Keeps a substring of the current string contents, defined by a range of
 	 * characters.
 	 * @param start The position of the first character 
-	 * @param end
-	 * @return
+	 * @param end The position of the last character + 1
+	 * @return the substring within this range
 	 */
 	/*@ non_null @*/ public AnnotatedString substring(int start, int end)
 	{

--- a/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
@@ -290,7 +290,7 @@ public class LatexCleaner extends TextCleaner
 
 	/**
 	 * Removes LaTeX commands from a string
-	 * @param as The string to clean
+	 * @param as_out The string to clean
 	 * @return A string with the environments removed
 	 */
 	protected AnnotatedString removeMarkup(AnnotatedString as_out)

--- a/Source/Core/src/ca/uqac/lif/textidote/render/AnsiAdviceRenderer.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/render/AnsiAdviceRenderer.java
@@ -101,7 +101,8 @@ public class AnsiAdviceRenderer extends AdviceRenderer
 	 * the quick brown fox jumps over the lazy dog
 	 *     ^^^^^^^^^^^^^^^
 	 * </pre>
-	 * @param line The line of text
+	 * @param ad Advice to render
+	 * @param l The line of text
 	 * @param range The range to highlight
 	 */
 	protected void renderExcerpt(/*@ non_null @*/ Advice ad, /*@ non_null @*/ Line l, /*@ non_null @*/ Range range)

--- a/Source/Core/src/ca/uqac/lif/textidote/render/SinglelineAdviceRenderer.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/render/SinglelineAdviceRenderer.java
@@ -76,7 +76,9 @@ public class SinglelineAdviceRenderer extends AdviceRenderer
 	 * Renders a line of text and "highlights" a portion of it. The highlight here
 	 * is represented by printing the text red:
 	 * 
-	 * @param line
+	 * @param as
+	 *          The string that should get highlighted
+	 * @param l
 	 *          The line of text
 	 * @param range
 	 *          The range to highlight


### PR DESCRIPTION
This should fix all the messages showing up when running `ant javadoc`.