### PR TITLE
Fix capture groups implementation

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/as/AnnotatedString.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/as/AnnotatedString.java
@@ -820,7 +820,7 @@ public class AnnotatedString implements ExplanationQueryable
 			return null;
 		}
 		Match m = new Match(mat.group(), mat.start());
-		for (int i = 1 ; i < mat.groupCount(); i++)
+		for (int i = 0 ; i <= mat.groupCount(); i++)
 		{
 			m.addGroup(mat.group(i));
 		}

--- a/Source/Core/src/ca/uqac/lif/textidote/as/Match.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/as/Match.java
@@ -84,6 +84,8 @@ public class Match
 	
 	/**
 	 * Gets the capture group with given index 
+	 * group(0) always gives the string matching the whole pattern
+	 * group(1) is the first capture group
 	 * @param index The index of the capture group
 	 * @return The string corresponding to the capture group
 	 */
@@ -98,7 +100,7 @@ public class Match
 	 */
 	public int groupCount()
 	{
-		return m_groups.size();
+		return m_groups.size()-1;
 	}
 	
 	@Override

--- a/Source/Core/src/ca/uqac/lif/textidote/rules/RegexRule.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/rules/RegexRule.java
@@ -141,7 +141,7 @@ public class RegexRule extends Rule
 	protected String createMessage(Match match)
 	{
 		String out = m_message;
-		for (int i = 1; i < match.groupCount(); i++)
+		for (int i = 0; i <= match.groupCount(); i++)
 		{
 			String s = match.group(i);
 			if (s != null)

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/rules/CheckRegexTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/rules/CheckRegexTest.java
@@ -116,6 +116,16 @@ public class CheckRegexTest
 		List<Advice> ad_list = r.evaluate(in_string);
 		assertEquals(0, ad_list.size());
 	}
+	
+	@Test
+	public void testCmulP2()
+	{
+		AnnotatedString in_string = AnnotatedString.read(new Scanner("Antarctica mass change shows clear regional differences between \\gls{eais},\\gls{wais}, and \\gls{ap} \\citep{schroder_four_2019}\\citep{schroder_two_2020}"));
+		Rule r = m_rules.get("sh:c:mulp");
+		List<Advice> ad_list = r.evaluate(in_string);
+		assertEquals("Put all references in a single \\citep command", ad_list.get(0).getMessage());
+		assertEquals(1, ad_list.size());
+	}
 
 	@Test
 	public void test010_1()


### PR DESCRIPTION
There's a +1/-1 bug in the for which makes the added test fail. This PR fixes such problem by following the Java standard behaviour:
- match.group(0) always gives the string matching the whole pattern
- match.group(1) is the first capture group
