### PR TITLE
Improve --root command on corner case

### DIFF
--- a/Source/Core/src/ca/uqac/lif/textidote/Main.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/Main.java
@@ -412,8 +412,8 @@ public class Main
 					if (input_type == Linter.Language.LATEX || (filename.compareTo("--") == 0 && input_type == Linter.Language.UNSPECIFIED) || filename.endsWith(".tex"))
 					{
 						// LaTeX file
-						String root_dir = calculateRootDir(filename, map.getOptionValue("root"));
-						LatexCleaner latex_cleaner = new LatexCleaner(root_dir);
+						String cur_dir = calculateCurrentDir(filename);
+						LatexCleaner latex_cleaner = new LatexCleaner(cur_dir, map.getOptionValue("root"));
 						latex_cleaner.setIgnoreBeforeDocument(!read_all);
 						latex_cleaner.ignoreEnvironments(env_blacklist);
 						latex_cleaner.ignoreMacros(mac_blacklist);
@@ -641,8 +641,8 @@ public class Main
 				}
 				else
 				{
-					String root_dir = calculateRootDir(top_level_filename, map.getOptionValue("root"));
-					LatexCleaner latex_cleaner = new LatexCleaner(root_dir);
+					String cur_dir = calculateCurrentDir(top_level_filename);
+					LatexCleaner latex_cleaner = new LatexCleaner(cur_dir, map.getOptionValue("root"));
 					if (cmd_filenames.contains(filename))
 					{
 						latex_cleaner.setIgnoreBeforeDocument(!read_all);
@@ -941,26 +941,21 @@ public class Main
 	}
 	
 	/**
-	 * Calculate the location of the root dir, using the root if is provided.
-	 * Otherwise just use the current file location.
+	 * Calculate the location of the current directory for a given file.
 	 * @param current_filename The name of the file currently being processed
-	 * @param root The file of the root document
-	 * @return The location of the root dir
+	 * @return The location of the current active directory for this file
 	 */
-	protected static String calculateRootDir(String current_filename, /*@ nullable @*/ String root)
+	protected static String calculateCurrentDir(String current_filename)
 	{
-		if (root == null){
-			root = current_filename;
-		}
-		File f = new File(root);
-		String root_dir = f.getParent();
-		if (root_dir == null)
+		File f = new File(current_filename);
+		String cur_dir = f.getParent();
+		if (cur_dir == null)
 		{
 			// This happens if the filename is "--" or the file is in
 			// the current folder
-			root_dir = "";
+			cur_dir = "";
 		}
-		return root_dir;
+		return cur_dir;
 	}
 
 	/**

--- a/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/cleaning/latex/LatexCleaner.java
@@ -55,9 +55,14 @@ public class LatexCleaner extends TextCleaner
 	/*@ non_null @*/ protected final Set<String> m_macrosToIgnore = new HashSet<String>();
 
 	/**
+	 * The path of the current directory (location of the file to clean)
+	 */
+	protected final Path m_curDir;
+
+	/**
 	 * The path of the root dir
 	 */
-	protected final Path m_rootDir;
+	protected Path m_rootDir;
 
 	/**
 	 * A list of <em>non-commented</em> <code>input</code> and <code>include</code>
@@ -78,12 +83,14 @@ public class LatexCleaner extends TextCleaner
 
 	/**
 	 * Creates a new instance of the cleaner
-	 * @param root_dir Path to the root location
+	 * @param cur_dir Path to the location of the file to clean
+	 * @param root_dir Path to the root tex file if known
 	 */
-	public LatexCleaner(/*@ non_null @*/ String root_dir)
+	public LatexCleaner(/*@ non_null @*/ String cur_dir, /*@ nullable @*/ String root_dir)
 	{
 		super();
-		m_rootDir = Paths.get(root_dir);
+		m_curDir = Paths.get(cur_dir);
+		m_rootDir = root_dir == null ? null : Paths.get(root_dir).getParent();
 	}
 
 	/**
@@ -91,9 +98,8 @@ public class LatexCleaner extends TextCleaner
 	 */
 	public LatexCleaner()
 	{
-		super();
-		// Assume root dir is the working directory
-		m_rootDir = Paths.get("");
+		// Assume current dir is the working directory
+		this("", null);
 	}
 
 	/**
@@ -146,15 +152,19 @@ public class LatexCleaner extends TextCleaner
 		// Reset list of inner files every time we clean
 		m_innerFiles.clear();
 		AnnotatedString new_as = new AnnotatedString(as);
-		Path root = m_rootDir;
-		String root_directive = parseRoot(new_as);
-		if(root_directive != null){
-			root = root.resolve(Paths.get(root_directive)).getParent();
+		if(m_rootDir == null){
+			String root_directive = parseRoot(new_as);
+			if(root_directive != null){
+				m_rootDir = m_curDir.resolve(Paths.get(root_directive)).getParent();
+			}
+			else{
+				m_rootDir = m_curDir;
+			}
 		}
 		new_as = cleanComments(new_as);
 		new_as = removeEnvironments(new_as);
 		new_as = removeMacros(new_as);
-		fetchIncludes(new_as, root);
+		fetchIncludes(new_as);
 		//new_as = removeAllMarkup(new_as);
 		new_as = removeMarkup(new_as);
 		//new_as = simplifySpaces(new_as);
@@ -577,9 +587,8 @@ public class LatexCleaner extends TextCleaner
 	 * <code>include</code> declarations found in the file to be cleaned.
 	 * @param as The contents of the file (where environments and
 	 * comments have already been removed).
-	 * @param root Root location
 	 */
-	protected void fetchIncludes(/*@ non_null @*/ AnnotatedString as, /*@ non_null @*/ Path root)
+	protected void fetchIncludes(/*@ non_null @*/ AnnotatedString as)
 	{
 		for (Line l : as.getLines())
 		{
@@ -592,7 +601,7 @@ public class LatexCleaner extends TextCleaner
 				{
 					filename += ".tex";
 				}
-				Path filepath = root.resolve(Paths.get(filename));
+				Path filepath = m_rootDir.resolve(Paths.get(filename));
 				m_innerFiles.add(filepath.toString());
 			}
 		}

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/MainTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/MainTest.java
@@ -332,7 +332,22 @@ public class MainTest
 		assertTrue(output.indexOf("child section")!=-1);
 		assertTrue(output.indexOf("child sibling section")!=-1);
 	}
-  
+
+	@Test
+	public void testIncludeWithRootBothWays() throws IOException
+	{
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		PrintStream out = new PrintStream(baos);
+		int ret_code = Main.mainLoop(new String[] {"--read-all", "--root", "rules/data/root.tex", "--output", "html", "rules/data/childs/child-section.tex"}, null, out, new NullPrintStream(), MainTest.class);
+		String output = new String(baos.toByteArray());
+		assertNotNull(output);
+		assertEquals(0, ret_code);
+		assertFalse(output.trim().isEmpty());
+		// Check that the desired sections are present
+		assertTrue(output.indexOf("child section")!=-1);
+		assertTrue(output.indexOf("child sibling section")!=-1);
+	}
+
 	@Test
 	public void testBeamerFile() throws IOException
 	{


### PR DESCRIPTION
In #242 I mentioned that there's a corner case not handled correctly (using both `--root` and `%!TEX root` at the same time). This PR fixes and adds a test for that. `--root` will take precedence.

The fix moves more of the path resolving logic from Main into LatexCleaner. Note that now Main doesn't have to worry about root paths at all.