### PR TITLE
add `clickable` output mode

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -552,7 +552,7 @@ for the changes to take effect.
 
 ### Visual Studio Code integration
 
-Users of Visual Studio Code can integrate TeXtidote by calling it with the `--output singleline` and `--no-color` options and parse its results. Moreover, user [cphyc](https://github.com/cphyc) also wrote a nice [build task](https://github.com/sylvainhalle/textidote/issues/125#issue-603278987).
+Users of Visual Studio Code can integrate TeXtidote by calling it with the `--output singleline` and `--no-color` options and parse its results. You can also use `--output clickable` to get `file:line:column:` diagnostics that many editors can parse directly. Moreover, user [cphyc](https://github.com/cphyc) also wrote a nice [build task](https://github.com/sylvainhalle/textidote/issues/125#issue-603278987).
 
 ### Emacs integration
 

--- a/Source/Core/src/ca/uqac/lif/textidote/Main.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/Main.java
@@ -43,6 +43,7 @@ import ca.uqac.lif.textidote.cleaning.TextCleanerException;
 import ca.uqac.lif.textidote.cleaning.latex.LatexCleaner;
 import ca.uqac.lif.textidote.cleaning.markdown.MarkdownCleaner;
 import ca.uqac.lif.textidote.render.AnsiAdviceRenderer;
+import ca.uqac.lif.textidote.render.ClickableAdviceRenderer;
 import ca.uqac.lif.textidote.render.HtmlAdviceRenderer;
 import ca.uqac.lif.textidote.render.JsonAdviceRenderer;
 import ca.uqac.lif.textidote.render.SinglelineAdviceRenderer;
@@ -204,7 +205,7 @@ public class Main
 		cli_parser.addArgument(new Argument().withLongName("replace").withArgument("file").withDescription("Apply replacement patterns from file"));
 		cli_parser.addArgument(new Argument().withLongName("type").withArgument("x").withDescription("Input is of type x (tex or md)"));
 		cli_parser.addArgument(new Argument().withLongName("version").withDescription("Show version number"));
-		cli_parser.addArgument(new Argument().withLongName("output").withArgument("method").withDescription("Output as plain (default), json, html, or singleline"));
+		cli_parser.addArgument(new Argument().withLongName("output").withArgument("method").withDescription("Output as plain (default), json, html, singleline, or clickable"));
 		cli_parser.addArgument(new Argument().withLongName("ci").withDescription("Ignores the return code for CI usage"));
 		cli_parser.addArgument(new Argument().withLongName("encoding").withArgument("x").withDescription("Read files using encoding x"));
 		cli_parser.addArgument(new Argument().withLongName("single-file").withDescription("Don't read sub-files if any"));
@@ -554,6 +555,10 @@ public class Main
 			else if (output_method.compareToIgnoreCase("singleline") == 0)
 			{
 				renderer = new SinglelineAdviceRenderer(stdout);
+			}
+			else if (output_method.compareToIgnoreCase("clickable") == 0)
+			{
+				renderer = new ClickableAdviceRenderer(stdout);
 			}
 			else if (output_method.compareToIgnoreCase("json") == 0)
 			{

--- a/Source/Core/src/ca/uqac/lif/textidote/render/ClickableAdviceRenderer.java
+++ b/Source/Core/src/ca/uqac/lif/textidote/render/ClickableAdviceRenderer.java
@@ -1,0 +1,69 @@
+/*
+    TeXtidote, a linter for LaTeX documents
+    Copyright (C) 2018-2023  Sylvain Hallé
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package ca.uqac.lif.textidote.render;
+
+import java.util.List;
+import java.util.Map;
+
+import ca.uqac.lif.textidote.Advice;
+import ca.uqac.lif.textidote.as.Position;
+import ca.uqac.lif.textidote.as.PositionRange;
+import ca.uqac.lif.util.AnsiPrinter;
+
+/**
+ * Renders advice in a "file:line:column: message" format that can be parsed by
+ * many terminals and editors as clickable diagnostics.
+ */
+public class ClickableAdviceRenderer extends SinglelineAdviceRenderer
+{
+	/**
+	 * Creates a new advice renderer.
+	 *
+	 * @param printer
+	 *          The printer to which the advice will be printed
+	 */
+	public ClickableAdviceRenderer(AnsiPrinter printer)
+	{
+		super(printer);
+	}
+
+	@Override
+	public void render()
+	{
+		for (Map.Entry<String, List<Advice>> entry : m_advice.entrySet())
+		{
+			String filename = entry.getKey();
+			List<Advice> list = entry.getValue();
+			if (!list.isEmpty())
+			{
+				for (Advice ad : list)
+				{
+					PositionRange range = ad.getPositionRange();
+					Position start = range.getStart();
+					int line = Math.max(1, start.getLine() + 1);
+					int col = Math.max(1, start.getColumn() + 1);
+					m_printer.print(filename + ":" + line + ":" + col + ": ");
+					m_printer.print(
+							ad.getMessage().replaceAll("<suggestion>", "").replaceAll("</suggestion", "").trim());
+					renderExcerpt(ad.getReferenceString(), ad.getLine(), ad.getRange());
+					m_printer.println();
+				}
+			}
+		}
+	}
+}

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/MainTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/MainTest.java
@@ -665,6 +665,19 @@ public class MainTest
 	}
 
 	@Test
+	public void testClickableOutput() throws IOException
+	{
+		String in_path = new File(MainTest.class.getResource("rules/data/test-nobreak.tex").getFile()).getAbsolutePath();
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		PrintStream out = new PrintStream(baos);
+		int ret_code = Main.mainLoop(new String[] {"--read-all", "--output", "clickable", "--no-color", in_path}, null, out, new NullPrintStream(), null);
+		String output = new String(baos.toByteArray());
+		assertTrue(ret_code > 0);
+		assertContains(in_path + ":", output);
+		assertContains("You should not break lines manually", output);
+	}
+
+	@Test
 	public void testNoBreakOnHTMLWithDummyReplacement() throws IOException
 	{
 		File replace_file = new File(MainTest.class.getResource("rules/data/replace.txt").getFile());

--- a/Source/CoreTest/src/ca/uqac/lif/textidote/render/ClickableAdviceRendererTest.java
+++ b/Source/CoreTest/src/ca/uqac/lif/textidote/render/ClickableAdviceRendererTest.java
@@ -1,0 +1,81 @@
+/*
+    TeXtidote, a linter for LaTeX documents
+    Copyright (C) 2018-2023  Sylvain Hallé
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package ca.uqac.lif.textidote.render;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+import ca.uqac.lif.petitpoucet.function.strings.Range;
+import ca.uqac.lif.textidote.Advice;
+import ca.uqac.lif.textidote.Rule;
+import ca.uqac.lif.textidote.as.AnnotatedString;
+import ca.uqac.lif.textidote.as.Position;
+import ca.uqac.lif.util.AnsiPrinter;
+import static ca.uqac.lif.textidote.as.AnnotatedString.CRLF;
+
+public class ClickableAdviceRendererTest
+{
+	@Test
+	public void test1()
+	{
+		String filename = "file";
+		String rulename = "rule";
+		String line1 = "foo";
+		String line2 = "bar";
+		String message = "warning message";
+		AnnotatedString as = new AnnotatedString(line1 + CRLF + line2 + CRLF);
+		int startLine = 1;
+		int startCol = 0;
+		int endLine = 1;
+		int endCol = 2;
+		Position start = new Position(startLine, startCol);
+		Position end = new Position(endLine, endCol);
+		Range range = new Range(as.getIndex(start), as.getIndex(end));
+		Rule rule = new Rule(rulename)
+		{
+			@Override
+			public List<Advice> evaluate(/* @ non_null @ */ AnnotatedString s)
+			{
+				return new ArrayList<Advice>();
+			}
+			@Override
+			public String getDescription()
+			{
+				return "";
+			}
+		};
+		ArrayList<Advice> adList = new ArrayList<Advice>();
+		Advice ad = new Advice(rule, range, message, as, as.getLine(1));
+		adList.add(ad);
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		AnsiPrinter printer = new AnsiPrinter(baos);
+		printer.disableColors();
+		ClickableAdviceRenderer renderer = new ClickableAdviceRenderer(printer);
+		renderer.addAdvice(filename, as, adList);
+		renderer.render();
+		String output = new String(baos.toByteArray());
+		assertNotNull(output);
+		String expected = String.format(filename + ":" + (startLine + 1) + ":" + (startCol + 1) + ": " + message + " \"" + line2 + "\"%n");
+		assertEquals(expected, output);
+	}
+}


### PR DESCRIPTION
I don't know if there's another name for it, but when I tried to use textidote the default output mode `L00C00` doesn't go-to-source for my editor (VSCode) the way `file:line:col` mode does, so I added a clickable mode for me local fork which I thought you might also want to incorporate.

Disclaimer as I see lots of projects struggle with an influx of slop PRs: I've used AI-assisted programming tools for writing the patch, reviewed the code with moderate effort as I normally do not write Java, manually checked the produced output on my own thesis document. Feel free to close the PR or ask for any changes that will be of minimal workload for yourself. Thank you for creating and maintaining `textidote`.

